### PR TITLE
feat(#9): Add sign-in page with GitHub OAuth

### DIFF
--- a/app/signin/layout.tsx
+++ b/app/signin/layout.tsx
@@ -1,0 +1,15 @@
+export default function SignInLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <>
+      {/* Hide the global header on sign-in page for a cleaner auth experience */}
+      <style>{`
+        header { display: none; }
+      `}</style>
+      {children}
+    </>
+  )
+}

--- a/app/signin/page.tsx
+++ b/app/signin/page.tsx
@@ -1,0 +1,40 @@
+import { signIn } from "@/auth"
+import { Github } from "lucide-react"
+
+export default function SignInPage() {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-indigo-500 via-purple-500 to-fuchsia-500">
+      <div className="max-w-md w-full mx-4">
+        <div className="bg-[var(--color-surface)] backdrop-blur-xl rounded-2xl p-8 border border-white/10">
+          <div className="text-center mb-8">
+            <h1 className="text-3xl font-bold mb-2" style={{fontFamily: 'var(--font-space-grotesk)'}}>
+              Welcome to LaunchLog
+            </h1>
+            <p className="text-gray-400">
+              Sign in with GitHub to create your developer portfolio
+            </p>
+          </div>
+
+          <form
+            action={async () => {
+              "use server"
+              await signIn("github", { redirectTo: "/onboarding" })
+            }}
+          >
+            <button
+              type="submit"
+              className="w-full flex items-center justify-center gap-3 px-6 py-4 bg-[#24292F] hover:bg-[#2f363d] text-white rounded-xl transition-all font-medium"
+            >
+              <Github className="w-5 h-5" />
+              Continue with GitHub
+            </button>
+          </form>
+
+          <p className="text-xs text-gray-500 text-center mt-6">
+            By signing in, you agree to our Terms of Service and Privacy Policy
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -57,15 +57,15 @@ export default function Header() {
             Pricing
           </Link>
           <Link
-            href="/login"
+            href="/signin"
             className="text-[var(--color-text-secondary)] text-sm font-medium hover:text-[var(--color-text)] transition-colors"
           >
-            Login
+            Sign In
           </Link>
           <Link
-            href="/auth/github"
+            href="/signin"
             className="inline-flex items-center gap-2 bg-gradient-to-r from-indigo-500 via-purple-500 to-fuchsia-500 text-white px-5 py-2.5 rounded-lg text-sm font-semibold transition-all duration-300 hover:-translate-y-0.5 shadow-[0_4px_16px_rgba(99,102,241,0.3)] hover:shadow-[0_6px_24px_rgba(99,102,241,0.4)] focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
-            aria-label="Sign in with GitHub"
+            aria-label="Get started with LaunchLog"
           >
             <Github className="w-4 h-4" aria-hidden="true" />
             Get Started Free
@@ -120,17 +120,17 @@ export default function Header() {
             Pricing
           </Link>
           <Link
-            href="/login"
+            href="/signin"
             className="block text-[var(--color-text-secondary)] text-base font-medium hover:text-[var(--color-text)] transition-colors py-2"
             onClick={closeMobileMenu}
           >
-            Login
+            Sign In
           </Link>
           <Link
-            href="/auth/github"
+            href="/signin"
             className="flex items-center justify-center gap-2 bg-gradient-to-r from-indigo-500 via-purple-500 to-fuchsia-500 text-white px-5 py-3 rounded-lg text-base font-semibold transition-all duration-300 shadow-[0_4px_16px_rgba(99,102,241,0.3)] focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 mt-4"
             onClick={closeMobileMenu}
-            aria-label="Sign in with GitHub"
+            aria-label="Get started with LaunchLog"
           >
             <Github className="w-5 h-5" aria-hidden="true" />
             Get Started Free


### PR DESCRIPTION
## Summary

- Created sign-in page at `/signin` with GitHub OAuth button
- Uses server action with NextAuth to trigger signIn flow
- Redirects to `/onboarding` after successful authentication
- Updated Header navigation links to point to `/signin`
- Added layout to hide global header on sign-in page for clean auth experience
- Matches landing page aesthetic (gradient background, glassmorphism card)

## Changes

- `app/signin/page.tsx` - New sign-in page with GitHub OAuth button
- `app/signin/layout.tsx` - Layout to hide header on auth pages
- `components/Header.tsx` - Updated links from `/login` and `/auth/github` to `/signin`

## Test plan

- [ ] Navigate to `/signin` and verify page displays correctly
- [ ] Click "Continue with GitHub" button and verify OAuth flow initiates
- [ ] After successful auth, verify redirect to `/onboarding`
- [ ] Verify Header "Sign In" link navigates to `/signin`
- [ ] Verify "Get Started Free" button navigates to `/signin`
- [ ] Test on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)