### PR TITLE
feat(onboarding): Add repository selection onboarding flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Supabase Configuration
+NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+
+# GitHub OAuth (via NextAuth)
+AUTH_GITHUB_ID=your-github-oauth-client-id
+AUTH_GITHUB_SECRET=your-github-oauth-client-secret
+
+# NextAuth Secret
+AUTH_SECRET=your-nextauth-secret

--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -1,0 +1,223 @@
+import { getSupabaseAdmin } from "@/lib/supabase"
+import Image from "next/image"
+import { Star, ExternalLink, GitBranch } from "lucide-react"
+
+export const revalidate = 3600 // Revalidate every hour
+
+interface UserRepo {
+  id: string
+  repo_id: number
+  repo_name: string
+  repo_full_name: string
+  repo_url: string
+  repo_description: string | null
+  repo_language: string | null
+  repo_stars: number
+  display_order: number
+}
+
+interface PageProps {
+  params: Promise<{ username: string }>
+}
+
+const LANGUAGE_COLORS: Record<string, string> = {
+  TypeScript: "#3178c6",
+  JavaScript: "#f1e05a",
+  Python: "#3572A5",
+  Rust: "#dea584",
+  Go: "#00ADD8",
+  Java: "#b07219",
+  "C++": "#f34b7d",
+  C: "#555555",
+  Ruby: "#701516",
+  PHP: "#4F5D95",
+  Swift: "#F05138",
+  Kotlin: "#A97BFF",
+  Dart: "#00B4AB",
+  Vue: "#41b883",
+  HTML: "#e34c26",
+  CSS: "#563d7c",
+  Shell: "#89e051",
+  Scala: "#c22d40",
+}
+
+async function getUserByUsername(username: string) {
+  const supabase = getSupabaseAdmin()
+  // First try to find user by GitHub username in accounts table
+  const { data: account } = await supabase
+    .from("accounts")
+    .select("userId")
+    .eq("provider", "github")
+    .ilike("providerAccountId", username)
+    .single()
+
+  if (account) {
+    const { data: user } = await supabase
+      .from("users")
+      .select("*")
+      .eq("id", account.userId)
+      .single()
+    return user
+  }
+
+  // Fallback: try to find user by name
+  const { data: user } = await supabase
+    .from("users")
+    .select("*")
+    .ilike("name", username)
+    .single()
+
+  return user
+}
+
+async function getUserRepos(userId: string): Promise<UserRepo[]> {
+  const supabase = getSupabaseAdmin()
+  const { data: repos } = await supabase
+    .from("user_repos")
+    .select("*")
+    .eq("user_id", userId)
+    .order("display_order", { ascending: true })
+
+  return repos || []
+}
+
+export default async function ProfilePage({ params }: PageProps) {
+  const { username } = await params
+
+  // For now, show a placeholder if we can't find the user
+  // In production, this would query the database
+  const user = await getUserByUsername(username)
+
+  if (!user) {
+    // Show a "coming soon" placeholder instead of 404
+    // This allows the redirect to work even before the user has a profile
+    return (
+      <div className="min-h-screen bg-[var(--color-bg)] py-16 px-4">
+        <div className="max-w-4xl mx-auto text-center">
+          <div className="w-24 h-24 rounded-full bg-gradient-to-br from-indigo-500 via-purple-500 to-fuchsia-500 mx-auto mb-6 flex items-center justify-center">
+            <span className="text-4xl text-white font-bold">
+              {username.charAt(0).toUpperCase()}
+            </span>
+          </div>
+          <h1
+            className="text-3xl md:text-4xl font-bold mb-3"
+            style={{ fontFamily: "var(--font-space-grotesk)" }}
+          >
+            @{username}
+          </h1>
+          <p className="text-[var(--color-text-secondary)] text-lg mb-8">
+            Profile coming soon
+          </p>
+          <div className="inline-flex items-center gap-2 px-6 py-3 bg-[var(--color-surface)] border border-[var(--color-border)] rounded-xl text-[var(--color-text-secondary)]">
+            <GitBranch className="w-5 h-5" />
+            Setting up LaunchLog profile...
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  const repos = await getUserRepos(user.id)
+
+  return (
+    <div className="min-h-screen bg-[var(--color-bg)] py-16 px-4">
+      <div className="max-w-4xl mx-auto">
+        {/* Profile header */}
+        <div className="text-center mb-12">
+          {user.image ? (
+            <Image
+              src={user.image}
+              alt={user.name || username}
+              width={96}
+              height={96}
+              className="w-24 h-24 rounded-full mx-auto mb-6 border-4 border-[var(--color-border)]"
+            />
+          ) : (
+            <div className="w-24 h-24 rounded-full bg-gradient-to-br from-indigo-500 via-purple-500 to-fuchsia-500 mx-auto mb-6 flex items-center justify-center">
+              <span className="text-4xl text-white font-bold">
+                {(user.name || username).charAt(0).toUpperCase()}
+              </span>
+            </div>
+          )}
+          <h1
+            className="text-3xl md:text-4xl font-bold mb-2"
+            style={{ fontFamily: "var(--font-space-grotesk)" }}
+          >
+            {user.name || username}
+          </h1>
+          {user.email && (
+            <p className="text-[var(--color-text-secondary)]">{user.email}</p>
+          )}
+        </div>
+
+        {/* Projects section */}
+        <div>
+          <h2 className="text-xl font-semibold mb-6 flex items-center gap-2">
+            <GitBranch className="w-5 h-5 text-indigo-500" />
+            Showcased Projects
+          </h2>
+
+          {repos.length === 0 ? (
+            <div className="text-center py-12 bg-[var(--color-surface)] rounded-xl border border-[var(--color-border)]">
+              <p className="text-[var(--color-text-secondary)]">
+                No projects showcased yet
+              </p>
+            </div>
+          ) : (
+            <div className="grid gap-4 md:grid-cols-2">
+              {repos.map((repo) => (
+                <ProjectCard key={repo.id} repo={repo} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ProjectCard({ repo }: { repo: UserRepo }) {
+  const languageColor = repo.repo_language
+    ? LANGUAGE_COLORS[repo.repo_language] || "#6e7681"
+    : null
+
+  return (
+    <a
+      href={repo.repo_url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="block p-5 bg-[var(--color-surface)] border border-[var(--color-border)] rounded-xl hover:border-indigo-500/50 transition-all duration-200 group"
+    >
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <h3 className="font-semibold text-[var(--color-text)] group-hover:text-indigo-400 transition-colors">
+          {repo.repo_name}
+        </h3>
+        <ExternalLink className="w-4 h-4 text-[var(--color-text-secondary)] opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0" />
+      </div>
+
+      {repo.repo_description && (
+        <p className="text-sm text-[var(--color-text-secondary)] line-clamp-2 mb-3">
+          {repo.repo_description}
+        </p>
+      )}
+
+      <div className="flex items-center gap-4">
+        {repo.repo_language && (
+          <span className="inline-flex items-center gap-1.5 text-xs text-[var(--color-text-secondary)]">
+            <span
+              className="w-2.5 h-2.5 rounded-full"
+              style={{ backgroundColor: languageColor || "#6e7681" }}
+            />
+            {repo.repo_language}
+          </span>
+        )}
+        {repo.repo_stars > 0 && (
+          <span className="inline-flex items-center gap-1 text-xs text-[var(--color-text-secondary)]">
+            <Star className="w-3.5 h-3.5 fill-current text-amber-400" />
+            {repo.repo_stars.toLocaleString()}
+          </span>
+        )}
+      </div>
+    </a>
+  )
+}

--- a/app/api/github/repos/route.ts
+++ b/app/api/github/repos/route.ts
@@ -1,0 +1,116 @@
+import { auth } from "@/auth"
+import { getSupabaseAdmin } from "@/lib/supabase"
+import { NextResponse } from "next/server"
+
+interface GitHubRepo {
+  id: number
+  name: string
+  full_name: string
+  description: string | null
+  html_url: string
+  homepage: string | null
+  language: string | null
+  stargazers_count: number
+  forks_count: number
+  topics: string[]
+  private: boolean
+  fork: boolean
+  archived: boolean
+  updated_at: string
+}
+
+export async function GET() {
+  try {
+    const session = await auth()
+
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 }
+      )
+    }
+
+    // Get the user's GitHub access token from the accounts table
+    const supabase = getSupabaseAdmin()
+    const { data: account, error: accountError } = await supabase
+      .from("accounts")
+      .select("access_token")
+      .eq("userId", session.user.id)
+      .eq("provider", "github")
+      .single()
+
+    if (accountError || !account?.access_token) {
+      return NextResponse.json(
+        { error: "GitHub account not linked" },
+        { status: 400 }
+      )
+    }
+
+    // Fetch repos from GitHub API
+    const repos: GitHubRepo[] = []
+    let page = 1
+    const perPage = 100
+
+    while (true) {
+      const response = await fetch(
+        `https://api.github.com/user/repos?sort=updated&per_page=${perPage}&page=${page}&type=owner`,
+        {
+          headers: {
+            Authorization: `Bearer ${account.access_token}`,
+            Accept: "application/vnd.github.v3+json",
+            "User-Agent": "LaunchLog",
+          },
+        }
+      )
+
+      if (!response.ok) {
+        const errorText = await response.text()
+        console.error("GitHub API error:", response.status, errorText)
+        return NextResponse.json(
+          { error: "Failed to fetch repositories from GitHub" },
+          { status: response.status }
+        )
+      }
+
+      const pageRepos: GitHubRepo[] = await response.json()
+
+      if (pageRepos.length === 0) {
+        break
+      }
+
+      // Filter out forks and archived repos, only include public repos
+      const filteredRepos = pageRepos.filter(
+        (repo) => !repo.fork && !repo.archived && !repo.private
+      )
+
+      repos.push(...filteredRepos)
+      page++
+
+      // Safety limit
+      if (page > 10) break
+    }
+
+    // Transform to a cleaner format
+    const transformedRepos = repos.map((repo) => ({
+      id: repo.id,
+      name: repo.name,
+      fullName: repo.full_name,
+      description: repo.description,
+      url: repo.html_url,
+      homepage: repo.homepage,
+      language: repo.language,
+      stars: repo.stargazers_count,
+      forks: repo.forks_count,
+      topics: repo.topics,
+      updatedAt: repo.updated_at,
+    }))
+
+    return NextResponse.json({ repos: transformedRepos })
+  } catch (error) {
+    console.error("Error fetching GitHub repos:", error)
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/user/repos/route.ts
+++ b/app/api/user/repos/route.ts
@@ -1,0 +1,172 @@
+import { auth } from "@/auth"
+import { getSupabaseAdmin } from "@/lib/supabase"
+import { NextResponse } from "next/server"
+
+interface RepoSelection {
+  id: number
+  name: string
+  fullName: string
+  description: string | null
+  url: string
+  language: string | null
+  stars: number
+}
+
+export async function POST(request: Request) {
+  try {
+    const session = await auth()
+
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 }
+      )
+    }
+
+    const body = await request.json()
+    const { repos } = body as { repos: RepoSelection[] }
+
+    if (!Array.isArray(repos) || repos.length === 0) {
+      return NextResponse.json(
+        { error: "No repositories selected" },
+        { status: 400 }
+      )
+    }
+
+    const supabase = getSupabaseAdmin()
+
+    // Delete existing user repos (replace with new selection)
+    const { error: deleteError } = await supabase
+      .from("user_repos")
+      .delete()
+      .eq("user_id", session.user.id)
+
+    if (deleteError) {
+      console.error("Error deleting existing repos:", deleteError)
+      // Continue anyway - table might not exist yet or no records
+    }
+
+    // Insert new selections
+    const repoRecords = repos.map((repo, index) => ({
+      user_id: session.user.id,
+      repo_id: repo.id,
+      repo_name: repo.name,
+      repo_full_name: repo.fullName,
+      repo_url: repo.url,
+      repo_description: repo.description,
+      repo_language: repo.language,
+      repo_stars: repo.stars,
+      display_order: index,
+      created_at: new Date().toISOString(),
+    }))
+
+    const { error: insertError } = await supabase
+      .from("user_repos")
+      .insert(repoRecords)
+
+    if (insertError) {
+      console.error("Error inserting repos:", insertError)
+      return NextResponse.json(
+        { error: "Failed to save repository selections" },
+        { status: 500 }
+      )
+    }
+
+    // Get the user's GitHub username for redirect
+    const { data: account } = await supabase
+      .from("accounts")
+      .select("providerAccountId")
+      .eq("userId", session.user.id)
+      .eq("provider", "github")
+      .single()
+
+    // Fetch GitHub username from the user's profile
+    let username = session.user.name?.replace(/\s+/g, "") || "user"
+
+    if (account?.providerAccountId) {
+      // Get actual GitHub username
+      const { data: user } = await supabase
+        .from("users")
+        .select("name")
+        .eq("id", session.user.id)
+        .single()
+
+      if (user?.name) {
+        // Try to get GitHub username from account
+        const accessToken = await getAccessToken(session.user.id)
+        if (accessToken) {
+          const ghUser = await fetch("https://api.github.com/user", {
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+              "User-Agent": "LaunchLog",
+            },
+          })
+          if (ghUser.ok) {
+            const userData = await ghUser.json()
+            username = userData.login
+          }
+        }
+      }
+    }
+
+    return NextResponse.json({
+      success: true,
+      count: repos.length,
+      redirectUrl: `/${username}`,
+    })
+  } catch (error) {
+    console.error("Error saving user repos:", error)
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    )
+  }
+}
+
+async function getAccessToken(userId: string): Promise<string | null> {
+  const supabase = getSupabaseAdmin()
+  const { data } = await supabase
+    .from("accounts")
+    .select("access_token")
+    .eq("userId", userId)
+    .eq("provider", "github")
+    .single()
+
+  return data?.access_token || null
+}
+
+export async function GET() {
+  try {
+    const session = await auth()
+
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        { error: "Unauthorized" },
+        { status: 401 }
+      )
+    }
+
+    const supabase = getSupabaseAdmin()
+    const { data: repos, error } = await supabase
+      .from("user_repos")
+      .select("*")
+      .eq("user_id", session.user.id)
+      .order("display_order", { ascending: true })
+
+    if (error) {
+      console.error("Error fetching user repos:", error)
+      return NextResponse.json(
+        { error: "Failed to fetch saved repositories" },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json({ repos: repos || [] })
+  } catch (error) {
+    console.error("Error in GET /api/user/repos:", error)
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    )
+  }
+}

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -1,0 +1,332 @@
+"use client"
+
+import { useEffect, useState, useMemo, useCallback } from "react"
+import { useRouter } from "next/navigation"
+import { Search, Star, Check, Loader2, ChevronRight, Code } from "lucide-react"
+
+interface Repo {
+  id: number
+  name: string
+  fullName: string
+  description: string | null
+  url: string
+  homepage: string | null
+  language: string | null
+  stars: number
+  forks: number
+  topics: string[]
+  updatedAt: string
+}
+
+const LANGUAGE_COLORS: Record<string, string> = {
+  TypeScript: "#3178c6",
+  JavaScript: "#f1e05a",
+  Python: "#3572A5",
+  Rust: "#dea584",
+  Go: "#00ADD8",
+  Java: "#b07219",
+  "C++": "#f34b7d",
+  C: "#555555",
+  Ruby: "#701516",
+  PHP: "#4F5D95",
+  Swift: "#F05138",
+  Kotlin: "#A97BFF",
+  Dart: "#00B4AB",
+  Vue: "#41b883",
+  HTML: "#e34c26",
+  CSS: "#563d7c",
+  Shell: "#89e051",
+  Scala: "#c22d40",
+}
+
+export default function OnboardingPage() {
+  const router = useRouter()
+  const [repos, setRepos] = useState<Repo[]>([])
+  const [selectedRepos, setSelectedRepos] = useState<Set<number>>(new Set())
+  const [searchQuery, setSearchQuery] = useState("")
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchRepos = useCallback(async () => {
+    try {
+      setLoading(true)
+      setError(null)
+
+      const response = await fetch("/api/github/repos")
+
+      if (!response.ok) {
+        if (response.status === 401) {
+          router.push("/signin")
+          return
+        }
+        throw new Error("Failed to fetch repositories")
+      }
+
+      const data = await response.json()
+      setRepos(data.repos)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred")
+    } finally {
+      setLoading(false)
+    }
+  }, [router])
+
+  useEffect(() => {
+    fetchRepos()
+  }, [fetchRepos])
+
+  const filteredRepos = useMemo(() => {
+    if (!searchQuery.trim()) return repos
+
+    const query = searchQuery.toLowerCase()
+    return repos.filter(
+      (repo) =>
+        repo.name.toLowerCase().includes(query) ||
+        repo.description?.toLowerCase().includes(query) ||
+        repo.language?.toLowerCase().includes(query) ||
+        repo.topics.some((t) => t.toLowerCase().includes(query))
+    )
+  }, [repos, searchQuery])
+
+  function toggleRepo(repoId: number) {
+    setSelectedRepos((prev) => {
+      const next = new Set(prev)
+      if (next.has(repoId)) {
+        next.delete(repoId)
+      } else {
+        next.add(repoId)
+      }
+      return next
+    })
+  }
+
+  async function handleSubmit() {
+    if (selectedRepos.size === 0) {
+      setError("Please select at least one repository")
+      return
+    }
+
+    try {
+      setSaving(true)
+      setError(null)
+
+      const selectedRepoData = repos
+        .filter((repo) => selectedRepos.has(repo.id))
+        .map((repo) => ({
+          id: repo.id,
+          name: repo.name,
+          fullName: repo.fullName,
+          description: repo.description,
+          url: repo.url,
+          language: repo.language,
+          stars: repo.stars,
+        }))
+
+      const response = await fetch("/api/user/repos", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ repos: selectedRepoData }),
+      })
+
+      if (!response.ok) {
+        throw new Error("Failed to save selections")
+      }
+
+      const data = await response.json()
+      router.push(data.redirectUrl || "/")
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "An error occurred")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-[var(--color-bg)]">
+        <div className="text-center">
+          <Loader2 className="w-10 h-10 animate-spin text-indigo-500 mx-auto mb-4" />
+          <p className="text-[var(--color-text-secondary)]">
+            Loading your repositories...
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-[var(--color-bg)] py-12 px-4">
+      <div className="max-w-4xl mx-auto">
+        {/* Header */}
+        <div className="text-center mb-10">
+          <h1
+            className="text-3xl md:text-4xl font-bold mb-3"
+            style={{ fontFamily: "var(--font-space-grotesk)" }}
+          >
+            Select Your Best Work
+          </h1>
+          <p className="text-[var(--color-text-secondary)] text-lg max-w-xl mx-auto">
+            Choose the repositories you want to showcase on your LaunchLog
+            profile. You can change this later.
+          </p>
+        </div>
+
+        {/* Search */}
+        <div className="relative mb-6">
+          <Search className="absolute left-4 top-1/2 -translate-y-1/2 w-5 h-5 text-[var(--color-text-secondary)]" />
+          <input
+            type="text"
+            placeholder="Search by name, language, or topic..."
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            className="w-full pl-12 pr-4 py-3.5 bg-[var(--color-surface)] border border-[var(--color-border)] rounded-xl text-[var(--color-text)] placeholder:text-[var(--color-text-secondary)] focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent transition-all"
+          />
+        </div>
+
+        {/* Selection count */}
+        <div className="flex items-center justify-between mb-4">
+          <p className="text-sm text-[var(--color-text-secondary)]">
+            {filteredRepos.length} repositories
+            {searchQuery && ` matching "${searchQuery}"`}
+          </p>
+          <p className="text-sm font-medium text-indigo-500">
+            {selectedRepos.size} selected
+          </p>
+        </div>
+
+        {/* Error */}
+        {error && (
+          <div className="mb-6 p-4 bg-red-500/10 border border-red-500/20 rounded-xl text-red-400 text-sm">
+            {error}
+          </div>
+        )}
+
+        {/* Repo grid */}
+        <div className="grid gap-3 mb-8">
+          {filteredRepos.length === 0 ? (
+            <div className="text-center py-12 bg-[var(--color-surface)] rounded-xl border border-[var(--color-border)]">
+              <Code className="w-12 h-12 text-[var(--color-text-secondary)] mx-auto mb-4 opacity-50" />
+              <p className="text-[var(--color-text-secondary)]">
+                {searchQuery
+                  ? "No repositories match your search"
+                  : "No public repositories found"}
+              </p>
+            </div>
+          ) : (
+            filteredRepos.map((repo) => (
+              <RepoCard
+                key={repo.id}
+                repo={repo}
+                selected={selectedRepos.has(repo.id)}
+                onToggle={() => toggleRepo(repo.id)}
+              />
+            ))
+          )}
+        </div>
+
+        {/* Submit button */}
+        <div className="sticky bottom-6 flex justify-center">
+          <button
+            onClick={handleSubmit}
+            disabled={selectedRepos.size === 0 || saving}
+            className="inline-flex items-center gap-2.5 px-8 py-4 bg-gradient-to-r from-indigo-500 via-purple-500 to-fuchsia-500 text-white rounded-xl font-semibold text-lg transition-all duration-300 hover:-translate-y-0.5 shadow-[0_8px_24px_rgba(99,102,241,0.35)] hover:shadow-[0_12px_32px_rgba(99,102,241,0.45)] disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0"
+          >
+            {saving ? (
+              <>
+                <Loader2 className="w-5 h-5 animate-spin" />
+                Saving...
+              </>
+            ) : (
+              <>
+                Continue to Profile
+                <ChevronRight className="w-5 h-5" />
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function RepoCard({
+  repo,
+  selected,
+  onToggle,
+}: {
+  repo: Repo
+  selected: boolean
+  onToggle: () => void
+}) {
+  const languageColor = repo.language
+    ? LANGUAGE_COLORS[repo.language] || "#6e7681"
+    : null
+
+  return (
+    <button
+      onClick={onToggle}
+      className={`w-full text-left p-4 md:p-5 rounded-xl border-2 transition-all duration-200 ${
+        selected
+          ? "bg-indigo-500/10 border-indigo-500"
+          : "bg-[var(--color-surface)] border-[var(--color-border)] hover:border-[var(--color-text-secondary)]/30"
+      }`}
+    >
+      <div className="flex items-start gap-4">
+        {/* Checkbox */}
+        <div
+          className={`flex-shrink-0 w-6 h-6 rounded-md border-2 flex items-center justify-center transition-all ${
+            selected
+              ? "bg-indigo-500 border-indigo-500"
+              : "border-[var(--color-border)]"
+          }`}
+        >
+          {selected && <Check className="w-4 h-4 text-white" />}
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap mb-1.5">
+            <h3 className="font-semibold text-[var(--color-text)] truncate">
+              {repo.name}
+            </h3>
+            {repo.stars > 0 && (
+              <span className="inline-flex items-center gap-1 text-sm text-[var(--color-text-secondary)]">
+                <Star className="w-3.5 h-3.5 fill-current text-amber-400" />
+                {repo.stars.toLocaleString()}
+              </span>
+            )}
+          </div>
+
+          {repo.description && (
+            <p className="text-sm text-[var(--color-text-secondary)] line-clamp-2 mb-2">
+              {repo.description}
+            </p>
+          )}
+
+          <div className="flex items-center gap-3 flex-wrap">
+            {repo.language && (
+              <span className="inline-flex items-center gap-1.5 text-xs text-[var(--color-text-secondary)]">
+                <span
+                  className="w-2.5 h-2.5 rounded-full"
+                  style={{ backgroundColor: languageColor || "#6e7681" }}
+                />
+                {repo.language}
+              </span>
+            )}
+            {repo.topics.slice(0, 3).map((topic) => (
+              <span
+                key={topic}
+                className="px-2 py-0.5 text-xs bg-indigo-500/10 text-indigo-400 rounded-full"
+              >
+                {topic}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+    </button>
+  )
+}

--- a/auth.ts
+++ b/auth.ts
@@ -3,7 +3,15 @@ import GitHub from "next-auth/providers/github"
 import { SupabaseAdapter } from "@auth/supabase-adapter"
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
-  providers: [GitHub],
+  providers: [
+    GitHub({
+      authorization: {
+        params: {
+          scope: "read:user user:email repo",
+        },
+      },
+    }),
+  ],
   adapter: SupabaseAdapter({
     url: process.env.NEXT_PUBLIC_SUPABASE_URL!,
     secret: process.env.SUPABASE_SERVICE_ROLE_KEY!,

--- a/components/HeroSection.tsx
+++ b/components/HeroSection.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { Github } from "lucide-react";
 
 export default function HeroSection() {
@@ -43,14 +44,14 @@ export default function HeroSection() {
         role="group"
         aria-label="Call to action buttons"
       >
-        <a
-          href="/auth/github"
+        <Link
+          href="/signin"
           className="inline-flex items-center justify-center gap-2 bg-gradient-to-r from-indigo-500 via-purple-500 to-fuchsia-500 text-white px-5 py-2.5 rounded-lg text-sm font-semibold transition-all duration-300 hover:-translate-y-0.5 shadow-[0_4px_16px_rgba(99,102,241,0.3)] hover:shadow-[0_6px_24px_rgba(99,102,241,0.4)] focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"
           aria-label="Sign in with GitHub to connect your account"
         >
           <Github className="w-4 h-4" aria-hidden="true" />
           Sign in with GitHub
-        </a>
+        </Link>
         <a
           href="#example"
           className="inline-flex items-center justify-center bg-transparent border border-[var(--color-border)] text-[var(--color-text)] px-5 py-2.5 rounded-lg text-sm font-medium transition-all duration-200 hover:border-[var(--color-text)] focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2"

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,0 +1,19 @@
+import { createClient, SupabaseClient } from "@supabase/supabase-js"
+
+let supabaseInstance: SupabaseClient | null = null
+
+export function getSupabaseAdmin(): SupabaseClient {
+  if (supabaseInstance) {
+    return supabaseInstance
+  }
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+
+  if (!supabaseUrl || !supabaseKey) {
+    throw new Error("Missing Supabase environment variables")
+  }
+
+  supabaseInstance = createClient(supabaseUrl, supabaseKey)
+  return supabaseInstance
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,20 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "avatars.githubusercontent.com",
+        pathname: "/u/**",
+      },
+      {
+        protocol: "https",
+        hostname: "lh3.googleusercontent.com",
+        pathname: "/**",
+      },
+    ],
+  },
 };
 
 export default nextConfig;

--- a/types/next-auth.d.ts
+++ b/types/next-auth.d.ts
@@ -1,0 +1,9 @@
+import { DefaultSession } from "next-auth"
+
+declare module "next-auth" {
+  interface Session {
+    user: {
+      id: string
+    } & DefaultSession["user"]
+  }
+}


### PR DESCRIPTION
## Summary

- Add `/onboarding` page with multi-select repository UI for users to choose repos to showcase
- Create `/api/github/repos` endpoint to fetch user's GitHub repositories using OAuth access token
- Create `/api/user/repos` endpoint to save/retrieve selected repos in Supabase `user_repos` table
- Add `/[username]` profile page with ISR (1-hour revalidation) showing showcased projects

## Test plan

- [ ] Sign in with GitHub OAuth
- [ ] Verify redirect to `/onboarding` page
- [ ] Verify repositories load from GitHub API
- [ ] Test search/filter functionality by repo name, language, topic
- [ ] Select multiple repos and submit
- [ ] Verify redirect to `/{username}` profile page
- [ ] Verify selected repos display on profile page

## Technical Notes

- Uses NextAuth.js v5 beta with Supabase adapter
- GitHub OAuth scope updated to include `repo` for repository access
- Supabase admin client created lazily to avoid build-time errors
- Added `next/image` config for GitHub avatar URLs

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)