### PR TITLE
fix: Set secure flags for auth cookies

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -17,10 +17,16 @@ export async function middleware(request: NextRequest) {
           return request.cookies.get(name)?.value;
         },
         set(name: string, value: string, options) {
+          const secureOptions = {
+            ...options,
+            secure: true,
+            httpOnly: true,
+            sameSite: "lax" as const,
+          };
           request.cookies.set({
             name,
             value,
-            ...options,
+            ...secureOptions,
           });
           response = NextResponse.next({
             request: {
@@ -30,14 +36,20 @@ export async function middleware(request: NextRequest) {
           response.cookies.set({
             name,
             value,
-            ...options,
+            ...secureOptions,
           });
         },
         remove(name: string, options) {
+          const secureOptions = {
+            ...options,
+            secure: true,
+            httpOnly: true,
+            sameSite: "lax" as const,
+          };
           request.cookies.set({
             name,
             value: "",
-            ...options,
+            ...secureOptions,
           });
           response = NextResponse.next({
             request: {
@@ -47,7 +59,7 @@ export async function middleware(request: NextRequest) {
           response.cookies.set({
             name,
             value: "",
-            ...options,
+            ...secureOptions,
           });
         },
       },


### PR DESCRIPTION
## Summary

- Enforces secure cookie flags in middleware to prevent OWASP Top 10 vulnerabilities
- Sets `secure: true` to force HTTPS and prevent man-in-the-middle attacks
- Sets `httpOnly: true` to prevent XSS token theft via JavaScript
- Sets `sameSite: 'lax'` for CSRF protection
- Applied to both `set()` and `remove()` methods

## Related Issue

Fixes #71

## Test plan

- [x] Build succeeds locally (`npm run build`)
- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [x] ESLint passes (`npm run lint`)
- [x] Prettier formatting correct
- [ ] QA verification by Nitty

🤖 Generated with [Claude Code](https://claude.com/claude-code)