### PR TITLE
fix(#71): Use runtime protocol detection for secure cookie flag

### DIFF
--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -44,7 +44,9 @@ export function createSupabaseBrowserClient() {
 
   return createBrowserClient(supabaseUrl, supabaseAnonKey, {
     cookieOptions: {
-      secure: process.env.NODE_ENV === "production",
+      secure: typeof window !== 'undefined'
+        ? window.location.protocol === 'https:'
+        : true,  // Default secure for SSR
       sameSite: "lax",
     },
   })


### PR DESCRIPTION
## Summary
- Fixes insecure auth cookies issue (Bug #1, Iteration 4)
- Uses runtime protocol detection (`window.location.protocol`) instead of build-time `process.env.NODE_ENV`
- Preview deployments on HTTPS will now correctly set `secure: true`

## Root Cause
`process.env.NODE_ENV` is replaced at BUILD time, not runtime. Preview deployments built with `development` mode got `secure: false` baked into the bundle.

## Solution
```typescript
secure: typeof window !== 'undefined' 
  ? window.location.protocol === 'https:' 
  : true  // Default secure for SSR
```

## Test plan
- [x] Build passes locally (`npm run build`)
- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] Lint passes (`npm run lint`)
- [ ] Deploy to preview and verify cookies have `secure: true` on HTTPS
- [ ] Verify auth flow still works correctly

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)