### PR TITLE
fix(#71): Force secure cookies in server-side handlers

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -20,7 +20,12 @@ export async function GET(request: Request) {
           },
           setAll(cookiesToSet) {
             cookiesToSet.forEach(({ name, value, options }) =>
-              cookieStore.set(name, value, options)
+              cookieStore.set(name, value, {
+                ...options,
+                secure: true,        // Force HTTPS cookies
+                sameSite: "lax",     // CSRF protection
+                httpOnly: false,     // Supabase needs client access
+              })
             )
           },
         },

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -19,7 +19,12 @@ export async function createSupabaseServerClient() {
         setAll(cookiesToSet) {
           try {
             cookiesToSet.forEach(({ name, value, options }) =>
-              cookieStore.set(name, value, options)
+              cookieStore.set(name, value, {
+                ...options,
+                secure: true,        // Force HTTPS cookies
+                sameSite: "lax",     // CSRF protection
+                httpOnly: false,     // Supabase needs client access
+              })
             )
           } catch {
             // The `setAll` method was called from a Server Component.

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,10 +2,8 @@ import { createServerClient } from "@supabase/ssr";
 import { NextResponse, type NextRequest } from "next/server";
 
 export async function middleware(request: NextRequest) {
-  let response = NextResponse.next({
-    request: {
-      headers: request.headers,
-    },
+  let supabaseResponse = NextResponse.next({
+    request,
   });
 
   const supabase = createServerClient(
@@ -13,64 +11,43 @@ export async function middleware(request: NextRequest) {
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
-        get(name: string) {
-          return request.cookies.get(name)?.value;
+        getAll() {
+          return request.cookies.getAll();
         },
-        set(name: string, value: string, options) {
-          const secureOptions = {
-            ...options,
-            secure: true,
-            httpOnly: true,
-            sameSite: "lax" as const,
-          };
-          request.cookies.set({
-            name,
-            value,
-            ...secureOptions,
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) =>
+            request.cookies.set(name, value)
+          );
+          supabaseResponse = NextResponse.next({
+            request,
           });
-          response = NextResponse.next({
-            request: {
-              headers: request.headers,
-            },
-          });
-          response.cookies.set({
-            name,
-            value,
-            ...secureOptions,
-          });
-        },
-        remove(name: string, options) {
-          const secureOptions = {
-            ...options,
-            secure: true,
-            httpOnly: true,
-            sameSite: "lax" as const,
-          };
-          request.cookies.set({
-            name,
-            value: "",
-            ...secureOptions,
-          });
-          response = NextResponse.next({
-            request: {
-              headers: request.headers,
-            },
-          });
-          response.cookies.set({
-            name,
-            value: "",
-            ...secureOptions,
+          cookiesToSet.forEach(({ name, value, options }) => {
+            supabaseResponse.cookies.set(name, value, {
+              ...options,
+              secure: true,        // Force HTTPS cookies
+              sameSite: "lax",     // CSRF protection
+              httpOnly: false,     // Supabase needs client access
+            });
           });
         },
       },
-    },
+    }
   );
+
+  // IMPORTANT: Do NOT run code between createServerClient and
+  // supabase.auth.getUser(). A simple mistake could make it very hard to debug
+  // issues with users being randomly logged out.
 
   // Refresh the session by calling getUser()
   // This will refresh the session if it's expired and set the new cookies
-  await supabase.auth.getUser();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
-  return response;
+  // You can add protected routes logic here if needed
+  // For example, redirect to signin if not authenticated on protected routes
+
+  return supabaseResponse;
 }
 
 export const config = {


### PR DESCRIPTION
## Summary
- Forces `secure: true`, `sameSite: 'lax'`, `httpOnly: false` on all server-side cookie operations
- Updates `middleware.ts` to use the modern `getAll`/`setAll` API pattern
- Also fixes `app/auth/callback/route.ts` and `lib/supabase/server.ts` to force secure options

## Root Cause
OAuth sets cookies **server-side** during the GitHub callback flow. Previous iterations only fixed client-side code (`lib/supabase.ts`), but that code is ignored during OAuth because the callback route uses its own Supabase client.

## Changes
1. **middleware.ts** - Updated to use `getAll`/`setAll` API with forced secure cookie options
2. **app/auth/callback/route.ts** - Forces secure options in `setAll()` (this is where OAuth cookies are set)
3. **lib/supabase/server.ts** - Forces secure options in `setAll()` for all server-side operations

## Test Plan
- [x] TypeScript compiles without errors (`tsc --noEmit`)
- [x] Build succeeds (`npm run build`)
- [x] Lint passes (`npm run lint`)
- [ ] Manual test: Log in via GitHub on production, verify cookies have `Secure` flag

Fixes #71 (iteration 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)