### PR TITLE
fix(#71): Force secure cookies with httpOnly:false in middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -20,7 +20,7 @@ export async function middleware(request: NextRequest) {
           const secureOptions = {
             ...options,
             secure: true,
-            httpOnly: true,
+            httpOnly: false,  // Required for Supabase client-side access
             sameSite: "lax" as const,
           };
           request.cookies.set({
@@ -43,7 +43,7 @@ export async function middleware(request: NextRequest) {
           const secureOptions = {
             ...options,
             secure: true,
-            httpOnly: true,
+            httpOnly: false,  // Required for Supabase client-side access
             sameSite: "lax" as const,
           };
           request.cookies.set({


### PR DESCRIPTION
## Summary
- Changes `httpOnly: true` to `httpOnly: false` in middleware.ts server-side cookie configuration
- Keeps `secure: true` and `sameSite: 'lax'` for proper HTTPS and CSRF protection
- Fixes session persistence bug where Supabase client couldn't access auth cookies

## Root Cause
The middleware was setting `httpOnly: true` which prevents client-side JavaScript from accessing the cookies. Supabase SSR auth requires client-side access to manage auth state, so `httpOnly` must be `false`.

## Test plan
- [ ] Verify build passes (confirmed locally)
- [ ] Test login flow on deployed URL
- [ ] Verify cookies have `Secure` flag
- [ ] Verify cookies are accessible to Supabase client (no httpOnly)
- [ ] Confirm session persists across page refreshes

🤖 Generated with [Claude Code](https://claude.com/claude-code)