### PR TITLE
fix(#71): Improve sign-out button with loading state and error handling

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -177,12 +177,19 @@ export default function DashboardPage() {
     }
   }
 
+  const [signingOut, setSigningOut] = useState(false)
+
   const handleSignOut = async () => {
     try {
-      await fetch("/api/auth/signout", { method: "POST" })
-      router.push("/signin")
+      setSigningOut(true)
+      const response = await fetch("/api/auth/signout", { method: "POST" })
+      if (!response.ok) {
+        throw new Error("Failed to sign out")
+      }
+      router.push("/")
     } catch {
-      console.error("Failed to sign out")
+      setSigningOut(false)
+      setError("Failed to sign out. Please try again.")
     }
   }
 
@@ -325,10 +332,15 @@ export default function DashboardPage() {
             </div>
             <button
               onClick={handleSignOut}
-              className="p-2 text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-surface-elevated)] rounded-lg transition-all"
+              disabled={signingOut}
+              className="p-2 text-[var(--color-text-secondary)] hover:text-[var(--color-text)] hover:bg-[var(--color-surface-elevated)] rounded-lg transition-all disabled:opacity-50"
               title="Sign out"
             >
-              <LogOut className="w-4 h-4" />
+              {signingOut ? (
+                <Loader2 className="w-4 h-4 animate-spin" />
+              ) : (
+                <LogOut className="w-4 h-4" />
+              )}
             </button>
           </div>
         </div>
@@ -416,10 +428,15 @@ export default function DashboardPage() {
             {/* Sign out button */}
             <button
               onClick={handleSignOut}
-              className="p-2 text-[var(--color-text-secondary)] hover:text-red-500 hover:bg-red-500/10 rounded-lg transition-all"
+              disabled={signingOut}
+              className="p-2 text-[var(--color-text-secondary)] hover:text-red-500 hover:bg-red-500/10 rounded-lg transition-all disabled:opacity-50"
               title="Sign out"
             >
-              <LogOut className="w-5 h-5" />
+              {signingOut ? (
+                <Loader2 className="w-5 h-5 animate-spin" />
+              ) : (
+                <LogOut className="w-5 h-5" />
+              )}
             </button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Change redirect after sign-out from /signin to / (landing page)
- Add loading spinner during sign-out process
- Add error handling with user feedback via setError
- Validate API response before redirecting
- Disable buttons during sign-out to prevent double-clicks

## Test plan
- [ ] Click sign-out button in header
- [ ] Verify spinner appears while signing out
- [ ] Verify redirect to landing page (/) after sign-out
- [ ] Verify button is disabled during sign-out (no double-clicks)
- [ ] Verify error message appears if sign-out fails

## Related Issue
Closes #71 Bug #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)