### PR TITLE
feat: Add How It Works section to landing page (#46)

### DIFF
--- a/components/HowItWorksSection.tsx
+++ b/components/HowItWorksSection.tsx
@@ -1,43 +1,81 @@
 "use client";
 
-import { Github, Search, Share2 } from "lucide-react";
+import { Github, FolderCheck, Share2 } from "lucide-react";
 
 interface StepCardProps {
   stepNumber: number;
   icon: React.ReactNode;
+  iconBgClass: string;
   title: string;
   description: string;
+  isLast?: boolean;
 }
 
-function StepCard({ stepNumber, icon, title, description }: StepCardProps) {
+function StepCard({
+  stepNumber,
+  icon,
+  iconBgClass,
+  title,
+  description,
+  isLast = false,
+}: StepCardProps) {
   return (
-    <article className="bg-[var(--color-surface)] border border-[var(--color-border)] rounded-[var(--radius-lg)] p-6 md:p-7 transition-all duration-300 hover:border-[var(--color-primary)] hover:shadow-[var(--shadow-glow)] text-center">
-      {/* Step Number Badge with Gradient */}
-      <div
-        className="w-10 h-10 mx-auto mb-4 rounded-full bg-gradient-to-r from-indigo-500 via-purple-500 to-fuchsia-500 flex items-center justify-center text-white font-bold text-lg font-[family-name:var(--font-space-grotesk)]"
-        aria-hidden="true"
-      >
-        {stepNumber}
-      </div>
+    <div className="relative flex flex-col items-center">
+      {/* Connecting Line - visible on desktop, between cards */}
+      {!isLast && (
+        <div
+          className="hidden md:block absolute top-[52px] left-[calc(50%+60px)] w-[calc(100%-60px)] h-[2px] bg-gradient-to-r from-indigo-500/50 via-purple-500/50 to-fuchsia-500/50"
+          aria-hidden="true"
+        />
+      )}
 
-      {/* Icon */}
-      <div
-        className="w-12 h-12 mx-auto mb-4 rounded-[var(--radius-md)] bg-indigo-500/10 flex items-center justify-center"
-        aria-hidden="true"
-      >
-        {icon}
-      </div>
+      <article className="group relative bg-[var(--color-surface)] border border-[var(--color-border)] rounded-[var(--radius-lg)] p-6 md:p-7 transition-all duration-300 hover:border-[var(--color-primary)] hover:shadow-[var(--shadow-glow)] hover:-translate-y-1 text-center w-full">
+        {/* Step Number Badge with Gradient */}
+        <div
+          className="w-12 h-12 mx-auto mb-5 rounded-full bg-gradient-to-r from-indigo-500 via-purple-500 to-fuchsia-500 flex items-center justify-center text-white font-bold text-xl font-[family-name:var(--font-space-grotesk)] shadow-lg shadow-indigo-500/25 transition-transform duration-300 group-hover:scale-110"
+          aria-hidden="true"
+        >
+          {stepNumber}
+        </div>
 
-      {/* Title */}
-      <h3 className="font-[family-name:var(--font-space-grotesk)] text-lg font-bold mb-2">
-        {title}
-      </h3>
+        {/* Icon */}
+        <div
+          className={`w-14 h-14 mx-auto mb-5 rounded-[var(--radius-md)] flex items-center justify-center transition-transform duration-300 group-hover:scale-105 ${iconBgClass}`}
+          aria-hidden="true"
+        >
+          {icon}
+        </div>
 
-      {/* Description */}
-      <p className="text-sm text-[var(--color-text-secondary)] leading-relaxed">
-        {description}
-      </p>
-    </article>
+        {/* Title */}
+        <h3 className="font-[family-name:var(--font-space-grotesk)] text-lg md:text-xl font-bold mb-3">
+          {title}
+        </h3>
+
+        {/* Description */}
+        <p className="text-sm md:text-base text-[var(--color-text-secondary)] leading-relaxed">
+          {description}
+        </p>
+      </article>
+
+      {/* Mobile Connecting Arrow */}
+      {!isLast && (
+        <div className="md:hidden flex justify-center my-4" aria-hidden="true">
+          <svg
+            className="w-6 h-6 text-indigo-500/50"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M19 14l-7 7m0 0l-7-7m7 7V3"
+            />
+          </svg>
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -45,24 +83,27 @@ export default function HowItWorksSection() {
   const steps = [
     {
       stepNumber: 1,
-      icon: <Github className="w-6 h-6 text-indigo-500" />,
+      icon: <Github className="w-7 h-7 text-indigo-500" />,
+      iconBgClass: "bg-indigo-500/10",
       title: "Connect GitHub",
       description:
-        "Auto-sync your repositories and keep your portfolio always up-to-date with your latest work.",
+        "Sign in with your GitHub account to get started in seconds. No setup required.",
     },
     {
       stepNumber: 2,
-      icon: <Search className="w-6 h-6 text-orange-500" />,
-      title: "Track Mentions",
+      icon: <FolderCheck className="w-7 h-7 text-purple-500" />,
+      iconBgClass: "bg-purple-500/10",
+      title: "Select Repos",
       description:
-        "We scan HackerNews, Product Hunt, Twitter, and Reddit to find every mention of your projects.",
+        "Choose which projects to showcase. We'll automatically keep them in sync.",
     },
     {
       stepNumber: 3,
-      icon: <Share2 className="w-6 h-6 text-cyan-500" />,
-      title: "Share Your Impact",
+      icon: <Share2 className="w-7 h-7 text-fuchsia-500" />,
+      iconBgClass: "bg-fuchsia-500/10",
+      title: "Share Your Profile",
       description:
-        "Beautiful portfolio page + embeddable widgets to showcase your work anywhere.",
+        "Get a beautiful portfolio page at launchlog.com/username. Embed it anywhere.",
     },
   ];
 
@@ -79,24 +120,26 @@ export default function HowItWorksSection() {
         >
           How it works
         </h2>
-        <p className="text-base md:text-lg text-[var(--color-text-secondary)]">
-          Three simple steps to showcase your developer impact
+        <p className="text-base md:text-lg text-[var(--color-text-secondary)] max-w-lg mx-auto">
+          Get started in three simple steps
         </p>
       </header>
 
       {/* Steps Grid - 1 column on mobile, 3 columns on desktop */}
       <div
-        className="grid grid-cols-1 md:grid-cols-3 gap-6"
+        className="grid grid-cols-1 md:grid-cols-3 gap-6 md:gap-8"
         role="list"
         aria-label="How it works steps"
       >
-        {steps.map((step) => (
+        {steps.map((step, index) => (
           <div key={step.stepNumber} role="listitem">
             <StepCard
               stepNumber={step.stepNumber}
               icon={step.icon}
+              iconBgClass={step.iconBgClass}
               title={step.title}
               description={step.description}
+              isLast={index === steps.length - 1}
             />
           </div>
         ))}


### PR DESCRIPTION
## Summary
- Revamp the "How It Works" section to match issue requirements
- Update the 3-step process: Connect GitHub → Select Repos → Share Profile
- Add visual progression with connecting gradient lines between steps
- Add mobile-friendly down arrows between steps

## Changes
- Updated step content to match issue #46 requirements:
  1. **Connect GitHub** - Sign in with your GitHub account
  2. **Select Repos** - Choose which projects to showcase
  3. **Share Your Profile** - Get a beautiful portfolio page
- Added horizontal connecting lines on desktop (gradient: indigo → purple → fuchsia)
- Added vertical down arrows on mobile for visual flow
- Enhanced hover effects with scale transforms
- Added shadow effects to step number badges

## Test plan
- [ ] Verify 3 clear steps displayed
- [ ] Step numbers and icons visible
- [ ] Visual flow/progression works
- [ ] Responsive design on mobile
- [ ] Consistent styling
- [ ] Smooth hover animations

🤖 Generated with [Claude Code](https://claude.com/claude-code)