### PR TITLE
fix(#95): Prevent re-onboarding on every signin

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,11 +1,13 @@
 import { createServerClient } from "@supabase/ssr"
 import { cookies } from "next/headers"
 import { NextResponse } from "next/server"
+import { getSupabaseAdmin } from "@/lib/supabase"
 
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url)
   const code = searchParams.get("code")
-  const next = searchParams.get("next") ?? "/onboarding"
+  // Default to onboarding, but we'll check if user has repos
+  const explicitNext = searchParams.get("next")
 
   if (code) {
     const cookieStore = await cookies()
@@ -35,15 +37,46 @@ export async function GET(request: Request) {
     const { error } = await supabase.auth.exchangeCodeForSession(code)
 
     if (!error) {
+      // Determine redirect destination
+      let redirectPath = explicitNext
+
+      // If no explicit next param, check if user has completed onboarding
+      if (!redirectPath) {
+        const {
+          data: { user },
+        } = await supabase.auth.getUser()
+
+        if (user) {
+          // Check if user has existing repos (completed onboarding)
+          const supabaseAdmin = getSupabaseAdmin()
+          const { data: userRepos, error: reposError } = await supabaseAdmin
+            .from("user_repos")
+            .select("id")
+            .eq("user_id", user.id)
+            .limit(1)
+
+          if (!reposError && userRepos && userRepos.length > 0) {
+            // User has repos, skip onboarding
+            redirectPath = "/dashboard"
+          } else {
+            // New user or no repos, go to onboarding
+            redirectPath = "/onboarding"
+          }
+        } else {
+          // No user found, default to onboarding
+          redirectPath = "/onboarding"
+        }
+      }
+
       const forwardedHost = request.headers.get("x-forwarded-host")
       const isLocalEnv = process.env.NODE_ENV === "development"
 
       if (isLocalEnv) {
-        return NextResponse.redirect(`${origin}${next}`)
+        return NextResponse.redirect(`${origin}${redirectPath}`)
       } else if (forwardedHost) {
-        return NextResponse.redirect(`https://${forwardedHost}${next}`)
+        return NextResponse.redirect(`https://${forwardedHost}${redirectPath}`)
       } else {
-        return NextResponse.redirect(`${origin}${next}`)
+        return NextResponse.redirect(`${origin}${redirectPath}`)
       }
     }
   }


### PR DESCRIPTION
## Summary
- Check `user_repos` table for existing records after auth callback
- Redirect returning users (with repos) directly to `/dashboard`
- New users (no repos) still go to `/onboarding`

## Test plan
- [ ] Sign in as new user → should see onboarding
- [ ] Sign in as existing user with repos → should go to dashboard
- [ ] Explicit `?next=` param still works

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)