### PR TITLE
fix(#96): Redirect signed-in users from homepage to dashboard

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,5 @@
+import { redirect } from "next/navigation";
+import { getUser } from "@/lib/supabase/server";
 import Header from "@/components/Header";
 import HeroSection from "@/components/HeroSection";
 import FeaturesSection from "@/components/FeaturesSection";
@@ -7,7 +9,13 @@ import PricingSection from "@/components/PricingSection";
 import FAQSection from "@/components/FAQSection";
 import Footer from "@/components/Footer";
 
-export default function Home() {
+export default async function Home() {
+  // Check if user is signed in - redirect to dashboard if so
+  const user = await getUser();
+  if (user) {
+    redirect("/dashboard");
+  }
+
   return (
     <>
       <Header />


### PR DESCRIPTION
## Summary
- Add server-side session check to homepage (`app/page.tsx`)
- If user has active session → redirect to `/dashboard`
- If no session → show landing page as before

## Test plan
- [ ] Signed-out user visits `/` → sees landing page
- [ ] Signed-in user visits `/` → redirects to `/dashboard`
- [ ] Build passes (`npm run build`)
- [ ] TypeScript check passes (`tsc --noEmit`)
- [ ] Lint passes (`npm run lint`)

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)