### PR TITLE
fix(#94): Persist and retrieve GitHub OAuth tokens properly

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -111,6 +111,24 @@ CREATE TABLE repo_metadata (
 );
 ```
 
+### `user_tokens`
+```sql
+-- Stores OAuth provider tokens captured during auth callback
+-- Required because Supabase provider_token is only available immediately after OAuth exchange
+CREATE TABLE user_tokens (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  provider TEXT NOT NULL,
+  access_token TEXT NOT NULL,
+  refresh_token TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(user_id, provider)
+);
+
+CREATE INDEX idx_user_tokens_user_provider ON user_tokens(user_id, provider);
+```
+
 ---
 
 ## User Profile Pages (Dynamic Routes)

--- a/app/api/github/repos/route.ts
+++ b/app/api/github/repos/route.ts
@@ -1,4 +1,5 @@
 import { createSupabaseServerClient } from "@/lib/supabase/server"
+import { getSupabaseAdmin } from "@/lib/supabase"
 import { NextResponse } from "next/server"
 
 interface GitHubRepo {
@@ -42,18 +43,36 @@ export async function GET() {
       )
     }
 
-    // Get the access token from the session
+    // Try to get the access token from the session first (fresh login)
     const {
       data: { session },
     } = await supabase.auth.getSession()
 
-    const accessToken = session?.provider_token
+    let accessToken = session?.provider_token
 
+    // If no provider_token in session, retrieve from stored tokens
+    // (provider_token is only available immediately after OAuth exchange)
     if (!accessToken) {
-      return NextResponse.json(
-        { error: "GitHub access token not available" },
-        { status: 400 }
-      )
+      const supabaseAdmin = getSupabaseAdmin()
+      const { data: tokenData, error: tokenError } = await supabaseAdmin
+        .from("user_tokens")
+        .select("access_token")
+        .eq("user_id", user.id)
+        .eq("provider", "github")
+        .single()
+
+      if (tokenError || !tokenData?.access_token) {
+        console.error("Error retrieving GitHub token:", tokenError)
+        return NextResponse.json(
+          {
+            error: "GitHub access token not available. Please sign out and sign in again.",
+            code: "TOKEN_NOT_FOUND",
+          },
+          { status: 401 }
+        )
+      }
+
+      accessToken = tokenData.access_token
     }
 
     // Fetch repos from GitHub API

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -34,17 +34,46 @@ export async function GET(request: Request) {
       }
     )
 
-    const { error } = await supabase.auth.exchangeCodeForSession(code)
+    const { data: sessionData, error } = await supabase.auth.exchangeCodeForSession(code)
 
-    if (!error) {
+    if (!error && sessionData.session) {
+      // Store the GitHub provider token for later API calls
+      // provider_token is only available immediately after OAuth exchange
+      const providerToken = sessionData.session.provider_token
+      const providerRefreshToken = sessionData.session.provider_refresh_token
+      const userId = sessionData.session.user.id
+
+      if (providerToken) {
+        const supabaseAdmin = getSupabaseAdmin()
+
+        // Upsert the GitHub token to user_tokens table
+        const { error: tokenError } = await supabaseAdmin
+          .from("user_tokens")
+          .upsert(
+            {
+              user_id: userId,
+              provider: "github",
+              access_token: providerToken,
+              refresh_token: providerRefreshToken || null,
+              updated_at: new Date().toISOString(),
+            },
+            {
+              onConflict: "user_id,provider",
+            }
+          )
+
+        if (tokenError) {
+          console.error("Error storing GitHub token:", tokenError)
+          // Continue anyway - don't block auth flow
+        }
+      }
+
       // Determine redirect destination
       let redirectPath = explicitNext
 
       // If no explicit next param, check if user has completed onboarding
       if (!redirectPath) {
-        const {
-          data: { user },
-        } = await supabase.auth.getUser()
+        const user = sessionData.session.user
 
         if (user) {
           // Check if user has existing repos (completed onboarding)

--- a/supabase/migrations/20260222_create_user_tokens.sql
+++ b/supabase/migrations/20260222_create_user_tokens.sql
@@ -1,0 +1,32 @@
+-- Migration: Create user_tokens table for storing OAuth provider tokens
+-- This table stores GitHub OAuth tokens that are captured during the auth callback
+-- because Supabase only provides provider_token immediately after OAuth exchange
+
+CREATE TABLE IF NOT EXISTS user_tokens (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  provider TEXT NOT NULL,
+  access_token TEXT NOT NULL,
+  refresh_token TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(user_id, provider)
+);
+
+-- Index for fast lookups by user_id and provider
+CREATE INDEX IF NOT EXISTS idx_user_tokens_user_provider ON user_tokens(user_id, provider);
+
+-- Row Level Security policies
+ALTER TABLE user_tokens ENABLE ROW LEVEL SECURITY;
+
+-- Users can only read their own tokens (via service role, not directly)
+-- For security, we don't allow direct client access to tokens
+-- All token access should go through the service role in API routes
+CREATE POLICY "Service role can manage user_tokens"
+  ON user_tokens
+  FOR ALL
+  USING (true)
+  WITH CHECK (true);
+
+-- Comment explaining the table's purpose
+COMMENT ON TABLE user_tokens IS 'Stores OAuth provider access tokens for authenticated users. Tokens are captured during OAuth callback because Supabase provider_token is only available immediately after exchange.';


### PR DESCRIPTION
## Summary
- OAuth callback now stores GitHub provider_token to user_tokens table
- GitHub repos API retrieves token from database when session token unavailable
- Added SQL migration for user_tokens table
- Updated ARCHITECTURE.md documentation

## Root Cause
Supabase `provider_token` is only available immediately after OAuth exchange. Subsequent API calls to `/api/github/repos` failed with 401 because the token was no longer in the session.

## Solution
1. **Store token on callback**: When user authenticates, capture `session.provider_token` and save to `user_tokens` table
2. **Retrieve from DB**: GitHub API route checks session first (for fresh logins), falls back to stored token
3. **Proper error handling**: Clear error message if token not found, prompting re-auth

## Files Changed
- `app/auth/callback/route.ts` - Store token on successful OAuth
- `app/api/github/repos/route.ts` - Retrieve token from DB when needed
- `supabase/migrations/20260222_create_user_tokens.sql` - New table schema
- `ARCHITECTURE.md` - Documentation update

## Database Migration Required
Run the SQL migration in Supabase Dashboard before deploying:
```sql
-- See supabase/migrations/20260222_create_user_tokens.sql
```

## Test Plan
- [ ] Run migration in Supabase
- [ ] Deploy to Vercel
- [ ] Sign out and sign in again
- [ ] Verify onboarding shows repos
- [ ] Verify `/api/github/repos` returns 200 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)