### PR TITLE
feat(#108): Build manual 'Add Mention' form

### DIFF
--- a/components/AddMentionForm.tsx
+++ b/components/AddMentionForm.tsx
@@ -1,0 +1,481 @@
+"use client";
+
+import { useState, useCallback, useEffect } from "react";
+import { Plus, Info, X, Loader2, Check } from "lucide-react";
+
+/**
+ * Platform type for mentions
+ */
+export type MentionPlatform = "hackernews" | "reddit";
+
+/**
+ * Form state for adding a mention
+ */
+interface AddMentionFormState {
+  platform: MentionPlatform;
+  url: string;
+  title: string;
+}
+
+/**
+ * Form validation errors
+ */
+interface FormErrors {
+  url?: string;
+  title?: string;
+  general?: string;
+}
+
+/**
+ * Props for AddMentionForm component
+ */
+interface AddMentionFormProps {
+  projectId: string;
+  onCancel: () => void;
+  onSuccess: () => void;
+  existingUrls?: string[];
+}
+
+/**
+ * HackerNews icon component (Y Combinator logo style)
+ */
+function HackerNewsIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M0 0v24h24V0H0zm12.4 14.8h-.8l-3.6-7.3h2l2.4 5.5 2.4-5.5h2l-3.6 7.3v4.3h-1.8l.8.1v-4.4z" />
+    </svg>
+  );
+}
+
+/**
+ * Reddit icon component
+ */
+function RedditIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+      aria-hidden="true"
+    >
+      <path d="M12 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0zm5.01 4.744c.688 0 1.25.561 1.25 1.249a1.25 1.25 0 0 1-2.498.056l-2.597-.547-.8 3.747c1.824.07 3.48.632 4.674 1.488.308-.309.73-.491 1.207-.491.968 0 1.754.786 1.754 1.754 0 .716-.435 1.333-1.01 1.614a3.111 3.111 0 0 1 .042.52c0 2.694-3.13 4.87-7.004 4.87-3.874 0-7.004-2.176-7.004-4.87 0-.183.015-.366.043-.534A1.748 1.748 0 0 1 4.028 12c0-.968.786-1.754 1.754-1.754.463 0 .898.196 1.207.49 1.207-.883 2.878-1.43 4.744-1.487l.885-4.182a.342.342 0 0 1 .14-.197.35.35 0 0 1 .238-.042l2.906.617a1.214 1.214 0 0 1 1.108-.701zM9.25 12C8.561 12 8 12.562 8 13.25c0 .687.561 1.248 1.25 1.248.687 0 1.248-.561 1.248-1.249 0-.688-.561-1.249-1.249-1.249zm5.5 0c-.687 0-1.248.561-1.248 1.25 0 .687.561 1.248 1.249 1.248.688 0 1.249-.561 1.249-1.249 0-.687-.562-1.249-1.25-1.249zm-5.466 3.99a.327.327 0 0 0-.231.094.33.33 0 0 0 0 .463c.842.842 2.484.913 2.961.913.477 0 2.105-.056 2.961-.913a.361.361 0 0 0 .029-.463.33.33 0 0 0-.464 0c-.547.533-1.684.73-2.512.73-.828 0-1.979-.196-2.512-.73a.326.326 0 0 0-.232-.095z" />
+    </svg>
+  );
+}
+
+/**
+ * URL validation patterns for each platform
+ */
+const URL_PATTERNS: Record<MentionPlatform, RegExp> = {
+  hackernews: /^https?:\/\/(news\.ycombinator\.com|hn\.algolia\.com)\/item\?id=\d+/i,
+  reddit: /^https?:\/\/(www\.)?(old\.)?reddit\.com\/r\/[a-zA-Z0-9_]+\/(comments|s)\/[a-zA-Z0-9]+/i,
+};
+
+/**
+ * URL placeholder text for each platform
+ */
+const URL_PLACEHOLDERS: Record<MentionPlatform, string> = {
+  hackernews: "https://news.ycombinator.com/item?id=...",
+  reddit: "https://www.reddit.com/r/reactjs/comments/...",
+};
+
+/**
+ * Validate URL for the selected platform
+ */
+function validateUrl(url: string, platform: MentionPlatform): string | undefined {
+  if (!url.trim()) {
+    return "URL is required";
+  }
+
+  try {
+    new URL(url);
+  } catch {
+    return "Please enter a valid URL";
+  }
+
+  if (!URL_PATTERNS[platform].test(url)) {
+    const platformName = platform === "hackernews" ? "HackerNews" : "Reddit";
+    return `Please enter a valid ${platformName} URL`;
+  }
+
+  return undefined;
+}
+
+/**
+ * Check if URL is a duplicate
+ */
+function isDuplicateUrl(url: string, existingUrls: string[]): boolean {
+  const normalizedUrl = url.toLowerCase().replace(/\/$/, "");
+  return existingUrls.some(
+    (existing) => existing.toLowerCase().replace(/\/$/, "") === normalizedUrl
+  );
+}
+
+/**
+ * AddMentionForm - Professional form for manually adding mentions
+ *
+ * Design based on mentions-system-v3.html (lines 1174-1306):
+ * - Header with icon, title, and description
+ * - Platform radio buttons (HackerNews, Reddit)
+ * - URL input with validation
+ * - Optional title field
+ * - Footer with Cancel and Submit buttons
+ * - Error states with inline feedback
+ */
+export function AddMentionForm({
+  projectId,
+  onCancel,
+  onSuccess,
+  existingUrls = [],
+}: AddMentionFormProps) {
+  const [formState, setFormState] = useState<AddMentionFormState>({
+    platform: "hackernews",
+    url: "",
+    title: "",
+  });
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [showSuccess, setShowSuccess] = useState(false);
+  const [touched, setTouched] = useState<Record<string, boolean>>({});
+
+  // Clear URL error when platform changes
+  useEffect(() => {
+    if (touched.url && formState.url) {
+      const urlError = validateUrl(formState.url, formState.platform);
+      setErrors((prev) => ({ ...prev, url: urlError }));
+    }
+  }, [formState.platform, formState.url, touched.url]);
+
+  // Handle platform change
+  const handlePlatformChange = useCallback((platform: MentionPlatform) => {
+    setFormState((prev) => ({ ...prev, platform }));
+  }, []);
+
+  // Handle URL change
+  const handleUrlChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const url = e.target.value;
+      setFormState((prev) => ({ ...prev, url }));
+
+      // Validate on change if field has been touched
+      if (touched.url) {
+        const urlError = validateUrl(url, formState.platform);
+        setErrors((prev) => ({ ...prev, url: urlError }));
+      }
+    },
+    [formState.platform, touched.url]
+  );
+
+  // Handle URL blur (mark as touched and validate)
+  const handleUrlBlur = useCallback(() => {
+    setTouched((prev) => ({ ...prev, url: true }));
+    const urlError = validateUrl(formState.url, formState.platform);
+    setErrors((prev) => ({ ...prev, url: urlError }));
+  }, [formState.url, formState.platform]);
+
+  // Handle title change
+  const handleTitleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setFormState((prev) => ({ ...prev, title: e.target.value }));
+    },
+    []
+  );
+
+  // Handle form submission
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+
+      // Validate URL
+      const urlError = validateUrl(formState.url, formState.platform);
+      if (urlError) {
+        setErrors({ url: urlError });
+        setTouched({ url: true });
+        return;
+      }
+
+      // Check for duplicates
+      if (isDuplicateUrl(formState.url, existingUrls)) {
+        setErrors({ url: "This mention has already been added" });
+        return;
+      }
+
+      setIsSubmitting(true);
+      setErrors({});
+
+      try {
+        const response = await fetch(
+          `/api/projects/${projectId}/mentions/${formState.platform}`,
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              url: formState.url,
+              title: formState.title || undefined,
+            }),
+          }
+        );
+
+        if (!response.ok) {
+          const data = await response.json().catch(() => ({}));
+          throw new Error(data.error || "Failed to add mention");
+        }
+
+        // Show success state briefly before closing
+        setShowSuccess(true);
+        setTimeout(() => {
+          onSuccess();
+        }, 1500);
+      } catch (err) {
+        const message =
+          err instanceof Error ? err.message : "Failed to add mention";
+        setErrors({ general: message });
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [formState, projectId, existingUrls, onSuccess]
+  );
+
+  // Determine if submit button should be disabled
+  const isSubmitDisabled =
+    isSubmitting ||
+    showSuccess ||
+    !formState.url.trim() ||
+    !!errors.url;
+
+  // Handle keyboard navigation
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onCancel();
+      }
+    },
+    [onCancel]
+  );
+
+  return (
+    <div
+      className="bg-[var(--color-surface)] border border-[var(--color-border)] rounded-[14px] max-w-[480px] w-full"
+      onKeyDown={handleKeyDown}
+      role="form"
+      aria-label="Add mention form"
+    >
+      {/* Header */}
+      <div className="flex items-center gap-3 px-6 py-5 border-b border-[var(--color-border)]">
+        <div className="w-9 h-9 rounded-[6px] bg-gradient-to-br from-indigo-500 via-purple-500 to-fuchsia-500 flex items-center justify-center flex-shrink-0">
+          {showSuccess ? (
+            <Check className="w-[18px] h-[18px] text-white" aria-hidden="true" />
+          ) : (
+            <Plus className="w-[18px] h-[18px] text-white" aria-hidden="true" />
+          )}
+        </div>
+        <div>
+          <h3 className="font-[family-name:var(--font-space-grotesk)] text-base font-bold">
+            {showSuccess ? "Mention Added" : "Add Mention"}
+          </h3>
+          <p className="text-xs text-[var(--color-text-secondary)]">
+            {showSuccess
+              ? "Successfully added to your project"
+              : "Manually add a discussion link"}
+          </p>
+        </div>
+      </div>
+
+      {/* Body */}
+      <form onSubmit={handleSubmit}>
+        <div className="px-6 py-6">
+          {/* General error message */}
+          {errors.general && (
+            <div
+              className="mb-5 p-3 rounded-[6px] bg-red-500/10 border border-red-500/20 text-red-500 text-sm flex items-center gap-2"
+              role="alert"
+            >
+              <X className="w-4 h-4 flex-shrink-0" aria-hidden="true" />
+              {errors.general}
+            </div>
+          )}
+
+          {/* Platform Selection */}
+          <div className="mb-5">
+            <label className="flex items-center justify-between text-[13px] font-semibold mb-2 text-[var(--color-text)]">
+              Platform
+            </label>
+            <div
+              className="flex gap-3 flex-col sm:flex-row"
+              role="radiogroup"
+              aria-label="Select platform"
+            >
+              {/* HackerNews Radio */}
+              <label className="flex-1 relative cursor-pointer">
+                <input
+                  type="radio"
+                  name="platform"
+                  value="hackernews"
+                  checked={formState.platform === "hackernews"}
+                  onChange={() => handlePlatformChange("hackernews")}
+                  className="sr-only"
+                  aria-describedby="hn-platform-label"
+                />
+                <span
+                  id="hn-platform-label"
+                  className={`flex items-center gap-2.5 px-3.5 py-3 rounded-[6px] border transition-all ${
+                    formState.platform === "hackernews"
+                      ? "border-[var(--color-primary)] bg-[rgba(99,102,241,0.08)]"
+                      : "border-[var(--color-border)] bg-[var(--color-surface-elevated)] hover:border-[var(--color-text-secondary)]"
+                  }`}
+                >
+                  <span className="w-6 h-6 rounded-[4px] bg-[rgba(255,102,0,0.15)] flex items-center justify-center">
+                    <HackerNewsIcon className="w-3.5 h-3.5 text-[#FF6600]" />
+                  </span>
+                  <span className="text-[13px] font-medium">HackerNews</span>
+                </span>
+              </label>
+
+              {/* Reddit Radio */}
+              <label className="flex-1 relative cursor-pointer">
+                <input
+                  type="radio"
+                  name="platform"
+                  value="reddit"
+                  checked={formState.platform === "reddit"}
+                  onChange={() => handlePlatformChange("reddit")}
+                  className="sr-only"
+                  aria-describedby="reddit-platform-label"
+                />
+                <span
+                  id="reddit-platform-label"
+                  className={`flex items-center gap-2.5 px-3.5 py-3 rounded-[6px] border transition-all ${
+                    formState.platform === "reddit"
+                      ? "border-[var(--color-primary)] bg-[rgba(99,102,241,0.08)]"
+                      : "border-[var(--color-border)] bg-[var(--color-surface-elevated)] hover:border-[var(--color-text-secondary)]"
+                  }`}
+                >
+                  <span className="w-6 h-6 rounded-[4px] bg-[rgba(255,69,0,0.15)] flex items-center justify-center">
+                    <RedditIcon className="w-3.5 h-3.5 text-[#FF4500]" />
+                  </span>
+                  <span className="text-[13px] font-medium">Reddit</span>
+                </span>
+              </label>
+            </div>
+          </div>
+
+          {/* URL Input */}
+          <div className="mb-5">
+            <label
+              htmlFor="mention-url"
+              className="flex items-center justify-between text-[13px] font-semibold mb-2 text-[var(--color-text)]"
+            >
+              URL
+              <span className="font-normal text-[var(--color-text-secondary)] text-[11px]">
+                Required
+              </span>
+            </label>
+            <input
+              id="mention-url"
+              type="url"
+              value={formState.url}
+              onChange={handleUrlChange}
+              onBlur={handleUrlBlur}
+              placeholder={URL_PLACEHOLDERS[formState.platform]}
+              className={`w-full px-3.5 py-3 bg-[var(--color-surface-elevated)] border rounded-[6px] text-sm text-[var(--color-text)] placeholder:text-[var(--color-text-secondary)] transition-all focus:outline-none focus:border-[var(--color-primary)] ${
+                errors.url && touched.url
+                  ? "border-red-500"
+                  : "border-[var(--color-border)]"
+              }`}
+              disabled={isSubmitting || showSuccess}
+              aria-invalid={!!errors.url}
+              aria-describedby={errors.url ? "url-error" : "url-hint"}
+            />
+            {errors.url && touched.url ? (
+              <p
+                id="url-error"
+                className="mt-1.5 text-xs text-red-500 flex items-center gap-1.5"
+                role="alert"
+              >
+                <X className="w-3 h-3" aria-hidden="true" />
+                {errors.url}
+              </p>
+            ) : (
+              <p
+                id="url-hint"
+                className="mt-1.5 text-xs text-[var(--color-text-secondary)] flex items-center gap-1.5"
+              >
+                <Info className="w-3 h-3" aria-hidden="true" />
+                Paste the full URL to the discussion
+              </p>
+            )}
+          </div>
+
+          {/* Title Input (Optional) */}
+          <div>
+            <label
+              htmlFor="mention-title"
+              className="flex items-center justify-between text-[13px] font-semibold mb-2 text-[var(--color-text)]"
+            >
+              Title
+              <span className="font-normal text-[var(--color-text-secondary)] text-[11px]">
+                Optional
+              </span>
+            </label>
+            <input
+              id="mention-title"
+              type="text"
+              value={formState.title}
+              onChange={handleTitleChange}
+              placeholder="Auto-fetched from URL"
+              className="w-full px-3.5 py-3 bg-[var(--color-surface-elevated)] border border-[var(--color-border)] rounded-[6px] text-sm text-[var(--color-text)] placeholder:text-[var(--color-text-secondary)] transition-all focus:outline-none focus:border-[var(--color-primary)]"
+              disabled={isSubmitting || showSuccess}
+            />
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-3 px-6 py-4 border-t border-[var(--color-border)]">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isSubmitting}
+            className="px-[18px] py-2.5 bg-transparent border border-[var(--color-border)] rounded-[6px] text-[13px] font-medium text-[var(--color-text-secondary)] transition-all hover:border-[var(--color-text-secondary)] hover:text-[var(--color-text)] disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={isSubmitDisabled}
+            className="inline-flex items-center gap-1.5 px-5 py-2.5 bg-gradient-to-r from-indigo-500 via-purple-500 to-fuchsia-500 border-none rounded-[6px] text-[13px] font-semibold text-white transition-all hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isSubmitting ? (
+              <>
+                <Loader2
+                  className="w-3.5 h-3.5 animate-spin"
+                  aria-hidden="true"
+                />
+                Adding...
+              </>
+            ) : showSuccess ? (
+              <>
+                <Check className="w-3.5 h-3.5" aria-hidden="true" />
+                Added!
+              </>
+            ) : (
+              <>
+                <Plus className="w-3.5 h-3.5" aria-hidden="true" />
+                Add Mention
+              </>
+            )}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+export default AddMentionForm;

--- a/components/__tests__/AddMentionForm.test.tsx
+++ b/components/__tests__/AddMentionForm.test.tsx
@@ -1,0 +1,644 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import AddMentionForm from "../AddMentionForm";
+
+// Mock fetch globally
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+const defaultProps = {
+  projectId: "test-project-id",
+  onCancel: jest.fn(),
+  onSuccess: jest.fn(),
+  existingUrls: [],
+};
+
+describe("AddMentionForm", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  describe("Rendering", () => {
+    it("renders the form with all elements", () => {
+      render(<AddMentionForm {...defaultProps} />);
+
+      // Header - use heading role for the h3
+      expect(screen.getByRole("heading", { name: "Add Mention" })).toBeInTheDocument();
+      expect(
+        screen.getByText("Manually add a discussion link")
+      ).toBeInTheDocument();
+
+      // Platform selection
+      expect(screen.getByText("Platform")).toBeInTheDocument();
+      expect(screen.getByText("HackerNews")).toBeInTheDocument();
+      expect(screen.getByText("Reddit")).toBeInTheDocument();
+
+      // URL input
+      expect(screen.getByLabelText(/URL/i)).toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText(/news\.ycombinator\.com/i)
+      ).toBeInTheDocument();
+
+      // Title input
+      expect(screen.getByLabelText(/Title/i)).toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText("Auto-fetched from URL")
+      ).toBeInTheDocument();
+
+      // Buttons
+      expect(
+        screen.getByRole("button", { name: /Cancel/i })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: /Add Mention/i })
+      ).toBeInTheDocument();
+    });
+
+    it("renders with HackerNews selected by default", () => {
+      render(<AddMentionForm {...defaultProps} />);
+
+      const hnRadio = screen.getByRole("radio", { name: /HackerNews/i });
+      expect(hnRadio).toBeChecked();
+
+      const redditRadio = screen.getByRole("radio", { name: /Reddit/i });
+      expect(redditRadio).not.toBeChecked();
+    });
+
+    it("shows hint text for URL field", () => {
+      render(<AddMentionForm {...defaultProps} />);
+
+      expect(
+        screen.getByText("Paste the full URL to the discussion")
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("Platform Selection", () => {
+    it("allows switching between HackerNews and Reddit", async () => {
+      const user = userEvent.setup();
+      render(<AddMentionForm {...defaultProps} />);
+
+      // Initially HackerNews is selected
+      expect(screen.getByRole("radio", { name: /HackerNews/i })).toBeChecked();
+
+      // Click Reddit
+      await user.click(screen.getByText("Reddit"));
+      expect(screen.getByRole("radio", { name: /Reddit/i })).toBeChecked();
+      expect(
+        screen.getByRole("radio", { name: /HackerNews/i })
+      ).not.toBeChecked();
+
+      // Click HackerNews again
+      await user.click(screen.getByText("HackerNews"));
+      expect(screen.getByRole("radio", { name: /HackerNews/i })).toBeChecked();
+    });
+
+    it("updates URL placeholder when platform changes", async () => {
+      const user = userEvent.setup();
+      render(<AddMentionForm {...defaultProps} />);
+
+      // Default HN placeholder
+      expect(
+        screen.getByPlaceholderText(/news\.ycombinator\.com/i)
+      ).toBeInTheDocument();
+
+      // Switch to Reddit
+      await user.click(screen.getByText("Reddit"));
+      expect(
+        screen.getByPlaceholderText(/reddit\.com\/r\/reactjs/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("URL Validation", () => {
+    it("shows error for empty URL on blur", async () => {
+      const user = userEvent.setup();
+      render(<AddMentionForm {...defaultProps} />);
+
+      const urlInput = screen.getByLabelText(/URL/i);
+      await user.click(urlInput);
+      await user.tab(); // Blur
+
+      expect(screen.getByText("URL is required")).toBeInTheDocument();
+    });
+
+    it("shows error for invalid URL format", async () => {
+      const user = userEvent.setup();
+      render(<AddMentionForm {...defaultProps} />);
+
+      const urlInput = screen.getByLabelText(/URL/i);
+      await user.type(urlInput, "not-a-valid-url");
+      await user.tab(); // Blur
+
+      expect(screen.getByText("Please enter a valid URL")).toBeInTheDocument();
+    });
+
+    it("shows error for URL that doesn't match HackerNews pattern", async () => {
+      const user = userEvent.setup();
+      render(<AddMentionForm {...defaultProps} />);
+
+      const urlInput = screen.getByLabelText(/URL/i);
+      await user.type(urlInput, "https://google.com");
+      await user.tab(); // Blur
+
+      expect(
+        screen.getByText("Please enter a valid HackerNews URL")
+      ).toBeInTheDocument();
+    });
+
+    it("shows error for URL that doesn't match Reddit pattern when Reddit is selected", async () => {
+      const user = userEvent.setup();
+      render(<AddMentionForm {...defaultProps} />);
+
+      // Switch to Reddit
+      await user.click(screen.getByText("Reddit"));
+
+      const urlInput = screen.getByLabelText(/URL/i);
+      await user.type(urlInput, "https://google.com");
+      await user.tab(); // Blur
+
+      expect(
+        screen.getByText("Please enter a valid Reddit URL")
+      ).toBeInTheDocument();
+    });
+
+    it("accepts valid HackerNews URL", async () => {
+      const user = userEvent.setup();
+      render(<AddMentionForm {...defaultProps} />);
+
+      const urlInput = screen.getByLabelText(/URL/i);
+      await user.type(
+        urlInput,
+        "https://news.ycombinator.com/item?id=12345678"
+      );
+      await user.tab(); // Blur
+
+      expect(
+        screen.queryByText(/Please enter a valid/i)
+      ).not.toBeInTheDocument();
+    });
+
+    it("accepts valid Reddit URL", async () => {
+      const user = userEvent.setup();
+      render(<AddMentionForm {...defaultProps} />);
+
+      // Switch to Reddit
+      await user.click(screen.getByText("Reddit"));
+
+      const urlInput = screen.getByLabelText(/URL/i);
+      await user.type(
+        urlInput,
+        "https://www.reddit.com/r/reactjs/comments/abc123/my_post"
+      );
+      await user.tab(); // Blur
+
+      expect(
+        screen.queryByText(/Please enter a valid/i)
+      ).not.toBeInTheDocument();
+    });
+
+    it("revalidates URL when platform changes", async () => {
+      const user = userEvent.setup();
+      render(<AddMentionForm {...defaultProps} />);
+
+      // Enter valid HN URL
+      const urlInput = screen.getByLabelText(/URL/i);
+      await user.type(
+        urlInput,
+        "https://news.ycombinator.com/item?id=12345678"
+      );
+      await user.tab(); // Blur
+
+      // No error initially
+      expect(
+        screen.queryByText(/Please enter a valid/i)
+      ).not.toBeInTheDocument();
+
+      // Switch to Reddit - should show error now
+      await user.click(screen.getByText("Reddit"));
+
+      expect(
+        screen.getByText("Please enter a valid Reddit URL")
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("Duplicate Detection", () => {
+    it("shows error for duplicate URL on submit", async () => {
+      const user = userEvent.setup();
+      const existingUrls = ["https://news.ycombinator.com/item?id=12345678"];
+
+      render(<AddMentionForm {...defaultProps} existingUrls={existingUrls} />);
+
+      const urlInput = screen.getByLabelText(/URL/i);
+      await user.type(
+        urlInput,
+        "https://news.ycombinator.com/item?id=12345678"
+      );
+
+      const submitButton = screen.getByRole("button", { name: /Add Mention/i });
+      await user.click(submitButton);
+
+      expect(
+        screen.getByText("This mention has already been added")
+      ).toBeInTheDocument();
+    });
+
+    it("detects duplicates regardless of trailing slash", async () => {
+      const user = userEvent.setup();
+      const existingUrls = ["https://news.ycombinator.com/item?id=12345678/"];
+
+      render(<AddMentionForm {...defaultProps} existingUrls={existingUrls} />);
+
+      const urlInput = screen.getByLabelText(/URL/i);
+      await user.type(
+        urlInput,
+        "https://news.ycombinator.com/item?id=12345678"
+      );
+
+      const submitButton = screen.getByRole("button", { name: /Add Mention/i });
+      await user.click(submitButton);
+
+      expect(
+        screen.getByText("This mention has already been added")
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("Form Submission", () => {
+    it("disables submit button when URL is empty", () => {
+      render(<AddMentionForm {...defaultProps} />);
+
+      const submitButton = screen.getByRole("button", { name: /Add Mention/i });
+      expect(submitButton).toBeDisabled();
+    });
+
+    it("enables submit button when valid URL is entered", async () => {
+      const user = userEvent.setup();
+      render(<AddMentionForm {...defaultProps} />);
+
+      const urlInput = screen.getByLabelText(/URL/i);
+      await user.type(
+        urlInput,
+        "https://news.ycombinator.com/item?id=12345678"
+      );
+
+      const submitButton = screen.getByRole("button", { name: /Add Mention/i });
+      expect(submitButton).not.toBeDisabled();
+    });
+
+    it("submits form with correct data for HackerNews", async () => {
+      const user = userEvent.setup();
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ id: "new-mention-id" }),
+      });
+
+      render(<AddMentionForm {...defaultProps} />);
+
+      const urlInput = screen.getByLabelText(/URL/i);
+      await user.type(
+        urlInput,
+        "https://news.ycombinator.com/item?id=12345678"
+      );
+
+      const titleInput = screen.getByLabelText(/Title/i);
+      await user.type(titleInput, "My Custom Title");
+
+      const submitButton = screen.getByRole("button", { name: /Add Mention/i });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          "/api/projects/test-project-id/mentions/hackernews",
+          {
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+              url: "https://news.ycombinator.com/item?id=12345678",
+              title: "My Custom Title",
+            }),
+          }
+        );
+      });
+    });
+
+    it("submits form with correct data for Reddit", async () => {
+      const user = userEvent.setup();
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ id: "new-mention-id" }),
+      });
+
+      render(<AddMentionForm {...defaultProps} />);
+
+      // Switch to Reddit
+      await user.click(screen.getByText("Reddit"));
+
+      const urlInput = screen.getByLabelText(/URL/i);
+      await user.type(
+        urlInput,
+        "https://www.reddit.com/r/reactjs/comments/abc123/my_post"
+      );
+
+      const submitButton = screen.getByRole("button", { name: /Add Mention/i });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          "/api/projects/test-project-id/mentions/reddit",
+          expect.objectContaining({
+            method: "POST",
+          })
+        );
+      });
+    });
+
+    it("shows loading state during submission", async () => {
+      const user = userEvent.setup();
+      mockFetch.mockImplementation(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(
+              () =>
+                resolve({
+                  ok: true,
+                  json: () => Promise.resolve({ id: "new-mention-id" }),
+                }),
+              100
+            )
+          )
+      );
+
+      render(<AddMentionForm {...defaultProps} />);
+
+      const urlInput = screen.getByLabelText(/URL/i);
+      await user.type(
+        urlInput,
+        "https://news.ycombinator.com/item?id=12345678"
+      );
+
+      const submitButton = screen.getByRole("button", { name: /Add Mention/i });
+      await user.click(submitButton);
+
+      expect(screen.getByText("Adding...")).toBeInTheDocument();
+    });
+
+    it("shows success state after successful submission", async () => {
+      const user = userEvent.setup();
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ id: "new-mention-id" }),
+      });
+
+      render(<AddMentionForm {...defaultProps} />);
+
+      const urlInput = screen.getByLabelText(/URL/i);
+      await user.type(
+        urlInput,
+        "https://news.ycombinator.com/item?id=12345678"
+      );
+
+      const submitButton = screen.getByRole("button", { name: /Add Mention/i });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(screen.getByText("Mention Added")).toBeInTheDocument();
+        expect(screen.getByText("Added!")).toBeInTheDocument();
+      });
+    });
+
+    it("calls onSuccess after successful submission", async () => {
+      jest.useFakeTimers();
+      const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+      const onSuccess = jest.fn();
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ id: "new-mention-id" }),
+      });
+
+      render(<AddMentionForm {...defaultProps} onSuccess={onSuccess} />);
+
+      const urlInput = screen.getByLabelText(/URL/i);
+      await user.type(
+        urlInput,
+        "https://news.ycombinator.com/item?id=12345678"
+      );
+
+      const submitButton = screen.getByRole("button", { name: /Add Mention/i });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(screen.getByText("Added!")).toBeInTheDocument();
+      });
+
+      // Fast-forward past success delay
+      jest.advanceTimersByTime(1500);
+
+      expect(onSuccess).toHaveBeenCalled();
+
+      jest.useRealTimers();
+    });
+
+    it("shows error message on API failure", async () => {
+      const user = userEvent.setup();
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        json: () => Promise.resolve({ error: "Server error occurred" }),
+      });
+
+      render(<AddMentionForm {...defaultProps} />);
+
+      const urlInput = screen.getByLabelText(/URL/i);
+      await user.type(
+        urlInput,
+        "https://news.ycombinator.com/item?id=12345678"
+      );
+
+      const submitButton = screen.getByRole("button", { name: /Add Mention/i });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(screen.getByText("Server error occurred")).toBeInTheDocument();
+      });
+    });
+
+    it("shows generic error message when API returns no error message", async () => {
+      const user = userEvent.setup();
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        json: () => Promise.reject(new Error("JSON parse error")),
+      });
+
+      render(<AddMentionForm {...defaultProps} />);
+
+      const urlInput = screen.getByLabelText(/URL/i);
+      await user.type(
+        urlInput,
+        "https://news.ycombinator.com/item?id=12345678"
+      );
+
+      const submitButton = screen.getByRole("button", { name: /Add Mention/i });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(screen.getByText("Failed to add mention")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("Cancel Button", () => {
+    it("calls onCancel when Cancel button is clicked", async () => {
+      const user = userEvent.setup();
+      const onCancel = jest.fn();
+
+      render(<AddMentionForm {...defaultProps} onCancel={onCancel} />);
+
+      const cancelButton = screen.getByRole("button", { name: /Cancel/i });
+      await user.click(cancelButton);
+
+      expect(onCancel).toHaveBeenCalled();
+    });
+
+    it("disables Cancel button during submission", async () => {
+      const user = userEvent.setup();
+      mockFetch.mockImplementation(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(
+              () =>
+                resolve({
+                  ok: true,
+                  json: () => Promise.resolve({ id: "new-mention-id" }),
+                }),
+              100
+            )
+          )
+      );
+
+      render(<AddMentionForm {...defaultProps} />);
+
+      const urlInput = screen.getByLabelText(/URL/i);
+      await user.type(
+        urlInput,
+        "https://news.ycombinator.com/item?id=12345678"
+      );
+
+      const submitButton = screen.getByRole("button", { name: /Add Mention/i });
+      await user.click(submitButton);
+
+      const cancelButton = screen.getByRole("button", { name: /Cancel/i });
+      expect(cancelButton).toBeDisabled();
+    });
+  });
+
+  describe("Keyboard Navigation", () => {
+    it("calls onCancel when Escape key is pressed", () => {
+      const onCancel = jest.fn();
+
+      render(<AddMentionForm {...defaultProps} onCancel={onCancel} />);
+
+      // Focus the form
+      const form = screen.getByRole("form");
+      fireEvent.keyDown(form, { key: "Escape" });
+
+      expect(onCancel).toHaveBeenCalled();
+    });
+
+    it("allows keyboard navigation to input fields", async () => {
+      const user = userEvent.setup();
+      render(<AddMentionForm {...defaultProps} />);
+
+      // Focus the URL input directly
+      const urlInput = screen.getByLabelText(/URL/i);
+      urlInput.focus();
+      expect(urlInput).toHaveFocus();
+
+      // Tab to Title input
+      await user.tab();
+      expect(screen.getByLabelText(/Title/i)).toHaveFocus();
+
+      // Tab to Cancel button
+      await user.tab();
+      expect(
+        screen.getByRole("button", { name: /Cancel/i })
+      ).toHaveFocus();
+
+      // Note: Submit button is disabled by default (no URL), so it doesn't receive focus
+      // This is expected behavior for accessibility
+    });
+  });
+
+  describe("Accessibility", () => {
+    it("has proper ARIA labels", () => {
+      render(<AddMentionForm {...defaultProps} />);
+
+      expect(
+        screen.getByRole("form", { name: /Add mention form/i })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole("radiogroup", { name: /Select platform/i })
+      ).toBeInTheDocument();
+    });
+
+    it("marks URL input as invalid when there is an error", async () => {
+      const user = userEvent.setup();
+      render(<AddMentionForm {...defaultProps} />);
+
+      const urlInput = screen.getByLabelText(/URL/i);
+      await user.type(urlInput, "invalid");
+      await user.tab();
+
+      expect(urlInput).toHaveAttribute("aria-invalid", "true");
+    });
+
+    it("has error messages with proper role", async () => {
+      const user = userEvent.setup();
+      render(<AddMentionForm {...defaultProps} />);
+
+      const urlInput = screen.getByLabelText(/URL/i);
+      await user.click(urlInput);
+      await user.tab();
+
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+  });
+
+  describe("Title Field", () => {
+    it("submits without title when not provided", async () => {
+      const user = userEvent.setup();
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve({ id: "new-mention-id" }),
+      });
+
+      render(<AddMentionForm {...defaultProps} />);
+
+      const urlInput = screen.getByLabelText(/URL/i);
+      await user.type(
+        urlInput,
+        "https://news.ycombinator.com/item?id=12345678"
+      );
+
+      // Don't fill title
+
+      const submitButton = screen.getByRole("button", { name: /Add Mention/i });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            body: JSON.stringify({
+              url: "https://news.ycombinator.com/item?id=12345678",
+              title: undefined,
+            }),
+          })
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `AddMentionForm` component for manually adding HackerNews and Reddit mentions
- Platform radio selection with visual feedback (HN/Reddit icons)
- URL validation with platform-specific pattern matching
- Duplicate mention detection before submission
- Optional title field (auto-fetched if not provided)
- Success/error states with loading indicators
- Full keyboard navigation and accessibility support (WCAG compliant)

## Design Reference
- Follows `/drafts/mentions-system-v3.html` lines 1174-1306
- Professional form styling with gradient buttons
- Inline error feedback
- Responsive layout (mobile-friendly)

## Acceptance Criteria
- [x] Form matches V3 design
- [x] Platform validation works
- [x] URL validation works (HN and Reddit patterns)
- [x] Prevents duplicate mentions
- [x] Shows success message on submit
- [x] Accessible (keyboard navigation, ARIA labels)
- [x] 31 test cases passing

## Test Plan
- [x] Run `npm test` - all tests pass
- [x] Run `npm run build` - build succeeds
- [x] Run `npm run lint` - no warnings or errors
- [ ] Manual testing in browser
- [ ] Test form submission with API endpoints

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)