### PR TITLE
feat(#122): Implement auto-screenshot capture for projects

### DIFF
--- a/__tests__/api/projects/screenshot/screenshot-utils.test.ts
+++ b/__tests__/api/projects/screenshot/screenshot-utils.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Tests for Screenshot Capture utility functions
+ *
+ * Issue #122: Implement auto-screenshot capture for projects
+ *
+ * Key functionality tested:
+ * 1. URL validation for screenshot capture
+ * 2. GitHub Open Graph URL generation
+ * 3. Screenshot configuration constants
+ */
+
+describe("Screenshot Utilities", () => {
+  /**
+   * Build GitHub Open Graph image URL as fallback
+   */
+  function buildGitHubOGUrl(repoFullName: string): string {
+    return `https://opengraph.githubassets.com/1/${repoFullName}`
+  }
+
+  /**
+   * Validate URL for screenshot capture
+   */
+  function isValidUrl(url: string): boolean {
+    try {
+      const parsed = new URL(url)
+      return ["http:", "https:"].includes(parsed.protocol)
+    } catch {
+      return false
+    }
+  }
+
+  describe("buildGitHubOGUrl", () => {
+    it("should generate correct GitHub OG URL for a repo", () => {
+      const result = buildGitHubOGUrl("heliosinnovations/launchlog")
+      expect(result).toBe(
+        "https://opengraph.githubassets.com/1/heliosinnovations/launchlog"
+      )
+    })
+
+    it("should handle repos with special characters", () => {
+      const result = buildGitHubOGUrl("user/repo-name_with.special")
+      expect(result).toBe(
+        "https://opengraph.githubassets.com/1/user/repo-name_with.special"
+      )
+    })
+
+    it("should generate URL for any owner/repo combination", () => {
+      const result = buildGitHubOGUrl("facebook/react")
+      expect(result).toBe("https://opengraph.githubassets.com/1/facebook/react")
+    })
+  })
+
+  describe("isValidUrl", () => {
+    it("should accept valid https URLs", () => {
+      expect(isValidUrl("https://example.com")).toBe(true)
+      expect(isValidUrl("https://sub.domain.example.com/path")).toBe(true)
+      expect(isValidUrl("https://example.com:8080/path?query=value")).toBe(true)
+    })
+
+    it("should accept valid http URLs", () => {
+      expect(isValidUrl("http://example.com")).toBe(true)
+      expect(isValidUrl("http://localhost:3000")).toBe(true)
+    })
+
+    it("should reject invalid URLs", () => {
+      expect(isValidUrl("not-a-url")).toBe(false)
+      expect(isValidUrl("example.com")).toBe(false)
+      expect(isValidUrl("")).toBe(false)
+      expect(isValidUrl("ftp://example.com")).toBe(false)
+      expect(isValidUrl("file:///path/to/file")).toBe(false)
+    })
+
+    it("should reject URLs with dangerous protocols", () => {
+      expect(isValidUrl("javascript:alert(1)")).toBe(false)
+      expect(isValidUrl("data:text/html,<script>alert(1)</script>")).toBe(false)
+    })
+  })
+
+  describe("Screenshot Configuration", () => {
+    const SCREENSHOT_CONFIG = {
+      viewport: { width: 1280, height: 720 },
+      navigationTimeout: 10000,
+      screenshotTimeout: 30000,
+      maxFileSize: 5 * 1024 * 1024, // 5MB
+      storageBucket: "project-screenshots",
+    }
+
+    it("should have correct viewport dimensions", () => {
+      expect(SCREENSHOT_CONFIG.viewport.width).toBe(1280)
+      expect(SCREENSHOT_CONFIG.viewport.height).toBe(720)
+    })
+
+    it("should have reasonable timeout values", () => {
+      expect(SCREENSHOT_CONFIG.navigationTimeout).toBe(10000) // 10 seconds
+      expect(SCREENSHOT_CONFIG.screenshotTimeout).toBe(30000) // 30 seconds
+    })
+
+    it("should enforce 5MB max file size", () => {
+      expect(SCREENSHOT_CONFIG.maxFileSize).toBe(5242880)
+    })
+
+    it("should use correct storage bucket name", () => {
+      expect(SCREENSHOT_CONFIG.storageBucket).toBe("project-screenshots")
+    })
+  })
+
+  describe("Screenshot filename generation", () => {
+    function generateFilename(projectId: string): string {
+      const timestamp = Date.now()
+      return `${projectId}_${timestamp}.png`
+    }
+
+    it("should generate unique filenames", () => {
+      const projectId = "test-project-id"
+      const filename1 = generateFilename(projectId)
+      const filename2 = generateFilename(projectId)
+
+      expect(filename1).toContain(projectId)
+      expect(filename1).toMatch(/\.png$/)
+      // Filenames should be different due to timestamp
+      // (may be same if generated at exact same millisecond)
+    })
+
+    it("should include project ID in filename", () => {
+      const projectId = "abc-123-def"
+      const filename = generateFilename(projectId)
+
+      expect(filename.startsWith(projectId)).toBe(true)
+    })
+
+    it("should use PNG extension", () => {
+      const filename = generateFilename("any-id")
+      expect(filename.endsWith(".png")).toBe(true)
+    })
+  })
+
+  describe("Error handling scenarios", () => {
+    it("should handle empty repo full name for GitHub OG URL", () => {
+      const result = buildGitHubOGUrl("")
+      expect(result).toBe("https://opengraph.githubassets.com/1/")
+    })
+
+    it("should handle URL validation edge cases", () => {
+      // URL with unicode
+      expect(isValidUrl("https://例え.jp/path")).toBe(true)
+
+      // URL with port
+      expect(isValidUrl("https://example.com:443")).toBe(true)
+
+      // URL with auth (though not recommended)
+      expect(isValidUrl("https://user:pass@example.com")).toBe(true)
+    })
+  })
+})

--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -17,6 +17,9 @@ interface UserRepo {
   repo_language: string | null
   repo_stars: number
   display_order: number
+  screenshot_url: string | null
+  screenshot_source: "captured" | "github_og" | null
+  live_demo_url: string | null
 }
 
 interface UserProfile {
@@ -395,48 +398,81 @@ function ProjectCard({ repo }: { repo: UserRepo }) {
     ? LANGUAGE_COLORS[repo.repo_language] || "#6e7681"
     : null
 
+  // Build GitHub OG URL as fallback
+  const githubOGUrl = `https://opengraph.githubassets.com/1/${repo.repo_full_name}`
+
+  // Determine display URL with fallback
+  const displayImageUrl = repo.screenshot_url || githubOGUrl
+
   return (
-    <div className="p-5 bg-[var(--color-surface)] border border-[var(--color-border)] rounded-xl hover:border-indigo-500/50 transition-all duration-200 group">
+    <div className="bg-[var(--color-surface)] border border-[var(--color-border)] rounded-xl overflow-hidden hover:border-indigo-500/50 transition-all duration-200 group">
+      {/* Screenshot preview */}
       <a
         href={repo.repo_url}
         target="_blank"
         rel="noopener noreferrer"
         className="block"
       >
-        <div className="flex items-start justify-between gap-3 mb-3">
-          <h3 className="font-semibold text-[var(--color-text)] group-hover:text-indigo-400 transition-colors">
-            {repo.repo_name}
-          </h3>
-          <ExternalLink className="w-4 h-4 text-[var(--color-text-secondary)] opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0" />
-        </div>
-
-        {repo.repo_description && (
-          <p className="text-sm text-[var(--color-text-secondary)] line-clamp-2 mb-3">
-            {repo.repo_description}
-          </p>
-        )}
-
-        <div className="flex items-center gap-4">
-          {repo.repo_language && (
-            <span className="inline-flex items-center gap-1.5 text-xs text-[var(--color-text-secondary)]">
-              <span
-                className="w-2.5 h-2.5 rounded-full"
-                style={{ backgroundColor: languageColor || "#6e7681" }}
-              />
-              {repo.repo_language}
-            </span>
-          )}
-          {repo.repo_stars > 0 && (
-            <span className="inline-flex items-center gap-1 text-xs text-[var(--color-text-secondary)]">
-              <Star className="w-3.5 h-3.5 fill-current text-amber-400" />
-              {repo.repo_stars.toLocaleString()}
-            </span>
+        <div className="relative aspect-video bg-[var(--color-surface-elevated)]">
+          <Image
+            src={displayImageUrl}
+            alt={`${repo.repo_name} preview`}
+            fill
+            className="object-cover"
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+          />
+          {/* Source badge */}
+          {repo.screenshot_source && (
+            <div className="absolute bottom-2 right-2 px-2 py-1 bg-black/60 backdrop-blur-sm rounded text-[10px] text-white font-medium">
+              {repo.screenshot_source === "captured" ? "Live Screenshot" : "GitHub Preview"}
+            </div>
           )}
         </div>
       </a>
 
-      {/* Mentions row - displays HN and Reddit mention counts */}
-      <MentionsRow projectId={repo.id} projectName={repo.repo_name} />
+      {/* Card content */}
+      <div className="p-5">
+        <a
+          href={repo.repo_url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="block"
+        >
+          <div className="flex items-start justify-between gap-3 mb-3">
+            <h3 className="font-semibold text-[var(--color-text)] group-hover:text-indigo-400 transition-colors">
+              {repo.repo_name}
+            </h3>
+            <ExternalLink className="w-4 h-4 text-[var(--color-text-secondary)] opacity-0 group-hover:opacity-100 transition-opacity flex-shrink-0" />
+          </div>
+
+          {repo.repo_description && (
+            <p className="text-sm text-[var(--color-text-secondary)] line-clamp-2 mb-3">
+              {repo.repo_description}
+            </p>
+          )}
+
+          <div className="flex items-center gap-4">
+            {repo.repo_language && (
+              <span className="inline-flex items-center gap-1.5 text-xs text-[var(--color-text-secondary)]">
+                <span
+                  className="w-2.5 h-2.5 rounded-full"
+                  style={{ backgroundColor: languageColor || "#6e7681" }}
+                />
+                {repo.repo_language}
+              </span>
+            )}
+            {repo.repo_stars > 0 && (
+              <span className="inline-flex items-center gap-1 text-xs text-[var(--color-text-secondary)]">
+                <Star className="w-3.5 h-3.5 fill-current text-amber-400" />
+                {repo.repo_stars.toLocaleString()}
+              </span>
+            )}
+          </div>
+        </a>
+
+        {/* Mentions row - displays HN and Reddit mention counts */}
+        <MentionsRow projectId={repo.id} projectName={repo.repo_name} />
+      </div>
     </div>
   )
 }

--- a/app/api/projects/[id]/screenshot/capture/route.ts
+++ b/app/api/projects/[id]/screenshot/capture/route.ts
@@ -1,0 +1,294 @@
+import { createSupabaseServerClient } from "@/lib/supabase/server"
+import { getSupabaseAdmin } from "@/lib/supabase"
+import { NextRequest, NextResponse } from "next/server"
+import { chromium, type Browser } from "playwright"
+
+/**
+ * Configuration for screenshot capture
+ */
+const SCREENSHOT_CONFIG = {
+  viewport: { width: 1280, height: 720 },
+  navigationTimeout: 10000,
+  screenshotTimeout: 30000,
+  maxFileSize: 5 * 1024 * 1024, // 5MB
+  storageBucket: "project-screenshots",
+}
+
+/**
+ * Build GitHub Open Graph image URL as fallback
+ */
+function buildGitHubOGUrl(repoFullName: string): string {
+  return `https://opengraph.githubassets.com/1/${repoFullName}`
+}
+
+/**
+ * Validate URL for screenshot capture
+ */
+function isValidUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url)
+    // Only allow http and https protocols
+    return ["http:", "https:"].includes(parsed.protocol)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Capture screenshot of a URL using Playwright
+ */
+async function captureScreenshot(url: string): Promise<Buffer | null> {
+  let browser: Browser | null = null
+
+  try {
+    // Launch headless Chromium
+    browser = await chromium.launch({
+      headless: true,
+      args: [
+        "--no-sandbox",
+        "--disable-setuid-sandbox",
+        "--disable-dev-shm-usage",
+        "--disable-accelerated-2d-canvas",
+        "--no-first-run",
+        "--no-zygote",
+        "--single-process",
+        "--disable-gpu",
+      ],
+    })
+
+    const context = await browser.newContext({
+      viewport: SCREENSHOT_CONFIG.viewport,
+      userAgent:
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
+    })
+
+    const page = await context.newPage()
+
+    // Navigate to URL with timeout
+    await page.goto(url, {
+      waitUntil: "networkidle",
+      timeout: SCREENSHOT_CONFIG.navigationTimeout,
+    })
+
+    // Wait a bit for dynamic content to settle
+    await page.waitForTimeout(2000)
+
+    // Capture screenshot as PNG
+    const screenshot = await page.screenshot({
+      type: "png",
+      fullPage: false, // Just viewport, not full page
+    })
+
+    await context.close()
+
+    return screenshot
+  } catch (error) {
+    console.error("Screenshot capture error:", error)
+    return null
+  } finally {
+    if (browser) {
+      await browser.close()
+    }
+  }
+}
+
+/**
+ * Upload screenshot to Supabase Storage
+ */
+async function uploadScreenshot(
+  projectId: string,
+  screenshot: Buffer
+): Promise<string | null> {
+  const supabaseAdmin = getSupabaseAdmin()
+  const timestamp = Date.now()
+  const filename = `${projectId}_${timestamp}.png`
+
+  // Check file size
+  if (screenshot.length > SCREENSHOT_CONFIG.maxFileSize) {
+    console.error("Screenshot exceeds max file size:", screenshot.length)
+    return null
+  }
+
+  const { data, error } = await supabaseAdmin.storage
+    .from(SCREENSHOT_CONFIG.storageBucket)
+    .upload(filename, screenshot, {
+      contentType: "image/png",
+      cacheControl: "3600",
+      upsert: true,
+    })
+
+  if (error) {
+    console.error("Storage upload error:", error)
+    return null
+  }
+
+  // Get public URL
+  const {
+    data: { publicUrl },
+  } = supabaseAdmin.storage
+    .from(SCREENSHOT_CONFIG.storageBucket)
+    .getPublicUrl(data.path)
+
+  return publicUrl
+}
+
+/**
+ * POST /api/projects/[id]/screenshot/capture
+ *
+ * Captures a screenshot of the project's live demo URL:
+ * 1. Validates user authentication and project ownership
+ * 2. Extracts live demo URL from project
+ * 3. Captures screenshot using Playwright headless browser
+ * 4. Uploads to Supabase Storage
+ * 5. Updates project record with screenshot URL
+ * 6. Falls back to GitHub OG image on failure
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id: projectId } = await params
+
+    // Validate project ID format (UUID)
+    const uuidRegex =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    if (!uuidRegex.test(projectId)) {
+      return NextResponse.json(
+        { error: "Invalid project ID format" },
+        { status: 400 }
+      )
+    }
+
+    // Get authenticated user
+    const supabase = await createSupabaseServerClient()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    // Get the project and verify ownership
+    const supabaseAdmin = getSupabaseAdmin()
+    const { data: project, error: projectError } = await supabaseAdmin
+      .from("user_repos")
+      .select("id, repo_full_name, repo_url, live_demo_url, user_id")
+      .eq("id", projectId)
+      .single()
+
+    if (projectError || !project) {
+      return NextResponse.json({ error: "Project not found" }, { status: 404 })
+    }
+
+    // Verify project ownership
+    if (project.user_id !== user.id) {
+      return NextResponse.json(
+        { error: "Not authorized to access this project" },
+        { status: 403 }
+      )
+    }
+
+    // Get body for optional live_demo_url override
+    let liveDemoUrl = project.live_demo_url
+    try {
+      const body = await request.json()
+      if (body.live_demo_url && isValidUrl(body.live_demo_url)) {
+        liveDemoUrl = body.live_demo_url
+      }
+    } catch {
+      // No body provided, use existing live_demo_url
+    }
+
+    let screenshotUrl: string | null = null
+    let screenshotSource: "captured" | "github_og" = "github_og"
+
+    // Attempt to capture screenshot if we have a valid live demo URL
+    if (liveDemoUrl && isValidUrl(liveDemoUrl)) {
+      console.log(`Attempting screenshot capture for: ${liveDemoUrl}`)
+
+      const screenshot = await captureScreenshot(liveDemoUrl)
+
+      if (screenshot) {
+        // Upload to storage
+        const uploadedUrl = await uploadScreenshot(projectId, screenshot)
+
+        if (uploadedUrl) {
+          screenshotUrl = uploadedUrl
+          screenshotSource = "captured"
+          console.log(`Screenshot captured successfully: ${screenshotUrl}`)
+        }
+      }
+
+      // Retry once on failure
+      if (!screenshotUrl) {
+        console.log("First capture attempt failed, retrying...")
+        const retryScreenshot = await captureScreenshot(liveDemoUrl)
+
+        if (retryScreenshot) {
+          const uploadedUrl = await uploadScreenshot(projectId, retryScreenshot)
+
+          if (uploadedUrl) {
+            screenshotUrl = uploadedUrl
+            screenshotSource = "captured"
+            console.log(`Screenshot captured on retry: ${screenshotUrl}`)
+          }
+        }
+      }
+    }
+
+    // Fallback to GitHub OG image
+    if (!screenshotUrl && project.repo_full_name) {
+      screenshotUrl = buildGitHubOGUrl(project.repo_full_name)
+      screenshotSource = "github_og"
+      console.log(`Using GitHub OG fallback: ${screenshotUrl}`)
+    }
+
+    // Update project record
+    const updateData: {
+      screenshot_url: string | null
+      screenshot_source: "captured" | "github_og" | null
+      screenshot_captured_at: string | null
+      live_demo_url?: string
+    } = {
+      screenshot_url: screenshotUrl,
+      screenshot_source: screenshotSource,
+      screenshot_captured_at: new Date().toISOString(),
+    }
+
+    // Update live_demo_url if provided
+    if (liveDemoUrl && liveDemoUrl !== project.live_demo_url) {
+      updateData.live_demo_url = liveDemoUrl
+    }
+
+    const { error: updateError } = await supabaseAdmin
+      .from("user_repos")
+      .update(updateData)
+      .eq("id", projectId)
+
+    if (updateError) {
+      console.error("Error updating project:", updateError)
+      return NextResponse.json(
+        { error: "Failed to update project with screenshot" },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json({
+      success: true,
+      screenshot_url: screenshotUrl,
+      screenshot_source: screenshotSource,
+      message:
+        screenshotSource === "captured"
+          ? "Screenshot captured successfully"
+          : "Using GitHub Open Graph image as fallback",
+    })
+  } catch (error) {
+    console.error("Error in screenshot capture API:", error)
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    )
+  }
+}

--- a/app/api/projects/[id]/screenshot/route.ts
+++ b/app/api/projects/[id]/screenshot/route.ts
@@ -1,0 +1,161 @@
+import { createSupabaseServerClient } from "@/lib/supabase/server"
+import { getSupabaseAdmin } from "@/lib/supabase"
+import { NextRequest, NextResponse } from "next/server"
+
+/**
+ * GET /api/projects/[id]/screenshot
+ *
+ * Get screenshot information for a project
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id: projectId } = await params
+
+    // Validate project ID format (UUID)
+    const uuidRegex =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    if (!uuidRegex.test(projectId)) {
+      return NextResponse.json(
+        { error: "Invalid project ID format" },
+        { status: 400 }
+      )
+    }
+
+    // Get authenticated user (optional for public access)
+    const supabase = await createSupabaseServerClient()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+
+    // Get the project
+    const supabaseAdmin = getSupabaseAdmin()
+    const { data: project, error: projectError } = await supabaseAdmin
+      .from("user_repos")
+      .select(
+        "id, repo_full_name, screenshot_url, screenshot_source, screenshot_captured_at, live_demo_url, user_id"
+      )
+      .eq("id", projectId)
+      .single()
+
+    if (projectError || !project) {
+      return NextResponse.json({ error: "Project not found" }, { status: 404 })
+    }
+
+    // Return screenshot info (public access allowed)
+    return NextResponse.json({
+      id: project.id,
+      screenshot_url: project.screenshot_url,
+      screenshot_source: project.screenshot_source,
+      screenshot_captured_at: project.screenshot_captured_at,
+      live_demo_url: user?.id === project.user_id ? project.live_demo_url : null,
+      can_capture: user?.id === project.user_id,
+    })
+  } catch (error) {
+    console.error("Error in screenshot GET API:", error)
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    )
+  }
+}
+
+/**
+ * PATCH /api/projects/[id]/screenshot
+ *
+ * Update the live demo URL for screenshot capture
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id: projectId } = await params
+
+    // Validate project ID format (UUID)
+    const uuidRegex =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    if (!uuidRegex.test(projectId)) {
+      return NextResponse.json(
+        { error: "Invalid project ID format" },
+        { status: 400 }
+      )
+    }
+
+    // Get authenticated user
+    const supabase = await createSupabaseServerClient()
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+
+    if (!user) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    }
+
+    // Get the project and verify ownership
+    const supabaseAdmin = getSupabaseAdmin()
+    const { data: project, error: projectError } = await supabaseAdmin
+      .from("user_repos")
+      .select("id, user_id")
+      .eq("id", projectId)
+      .single()
+
+    if (projectError || !project) {
+      return NextResponse.json({ error: "Project not found" }, { status: 404 })
+    }
+
+    // Verify project ownership
+    if (project.user_id !== user.id) {
+      return NextResponse.json(
+        { error: "Not authorized to access this project" },
+        { status: 403 }
+      )
+    }
+
+    // Parse request body
+    const body = await request.json()
+    const { live_demo_url } = body as { live_demo_url?: string }
+
+    // Validate URL if provided
+    if (live_demo_url) {
+      try {
+        const parsed = new URL(live_demo_url)
+        if (!["http:", "https:"].includes(parsed.protocol)) {
+          return NextResponse.json(
+            { error: "Invalid URL protocol" },
+            { status: 400 }
+          )
+        }
+      } catch {
+        return NextResponse.json({ error: "Invalid URL format" }, { status: 400 })
+      }
+    }
+
+    // Update the project
+    const { error: updateError } = await supabaseAdmin
+      .from("user_repos")
+      .update({ live_demo_url: live_demo_url || null })
+      .eq("id", projectId)
+
+    if (updateError) {
+      console.error("Error updating project:", updateError)
+      return NextResponse.json(
+        { error: "Failed to update live demo URL" },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json({
+      success: true,
+      live_demo_url: live_demo_url || null,
+    })
+  } catch (error) {
+    console.error("Error in screenshot PATCH API:", error)
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    )
+  }
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -21,6 +21,7 @@ import {
   Menu,
   X,
   User,
+  Camera,
 } from "lucide-react"
 import DashboardFooter from "@/components/DashboardFooter"
 
@@ -36,6 +37,9 @@ interface UserRepo {
   repo_stars: number
   display_order: number
   created_at: string
+  screenshot_url: string | null
+  screenshot_source: "captured" | "github_og" | null
+  live_demo_url: string | null
 }
 
 interface User {
@@ -639,49 +643,133 @@ export default function DashboardPage() {
   )
 }
 
-function RepoCard({ repo }: { repo: UserRepo }) {
+function RepoCard({ repo, onScreenshotCapture }: { repo: UserRepo; onScreenshotCapture?: (repoId: string) => void }) {
+  const [isCapturing, setIsCapturing] = useState(false)
+  const [screenshotUrl, setScreenshotUrl] = useState(repo.screenshot_url)
+  const [screenshotSource, setScreenshotSource] = useState(repo.screenshot_source)
+  const [imageError, setImageError] = useState(false)
+
   const languageColor = repo.repo_language
     ? LANGUAGE_COLORS[repo.repo_language] || "#6e7681"
     : null
 
+  // Build GitHub OG URL as fallback
+  const githubOGUrl = `https://opengraph.githubassets.com/1/${repo.repo_full_name}`
+
+  // Determine display URL with fallback
+  const displayImageUrl = imageError || !screenshotUrl ? githubOGUrl : screenshotUrl
+
+  const handleCapture = async (e: React.MouseEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+
+    if (!repo.live_demo_url) {
+      return
+    }
+
+    setIsCapturing(true)
+
+    try {
+      const response = await fetch(
+        `/api/projects/${repo.id}/screenshot/capture`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ live_demo_url: repo.live_demo_url }),
+        }
+      )
+
+      const data = await response.json()
+
+      if (response.ok) {
+        setScreenshotUrl(data.screenshot_url)
+        setScreenshotSource(data.screenshot_source)
+        setImageError(false)
+        if (onScreenshotCapture) {
+          onScreenshotCapture(repo.id)
+        }
+      }
+    } catch (error) {
+      console.error("Screenshot capture failed:", error)
+    } finally {
+      setIsCapturing(false)
+    }
+  }
+
   return (
-    <a
-      href={repo.repo_url}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="bg-[var(--color-surface)] border border-[var(--color-border)] rounded-2xl p-5 transition-all hover:border-indigo-500 hover:-translate-y-0.5"
-    >
-      <div className="flex items-start justify-between mb-3">
-        <span className="font-semibold">{repo.repo_name}</span>
-        <span className="px-2 py-1 bg-[var(--color-surface-elevated)] rounded text-[11px] text-[var(--color-text-secondary)] uppercase tracking-wide">
-          Public
-        </span>
-      </div>
-      {repo.repo_description && (
-        <p className="text-sm text-[var(--color-text-secondary)] line-clamp-2 mb-4">
-          {repo.repo_description}
-        </p>
-      )}
-      <div className="flex items-center gap-4">
-        {repo.repo_language && (
-          <span className="flex items-center gap-1.5 text-sm text-[var(--color-text-secondary)]">
-            <span
-              className="w-2.5 h-2.5 rounded-full"
-              style={{ backgroundColor: languageColor || "#6e7681" }}
-            />
-            {repo.repo_language}
-          </span>
+    <div className="bg-[var(--color-surface)] border border-[var(--color-border)] rounded-2xl overflow-hidden transition-all hover:border-indigo-500 hover:-translate-y-0.5">
+      {/* Screenshot preview */}
+      <div className="relative aspect-video bg-[var(--color-surface-elevated)]">
+        <Image
+          src={displayImageUrl}
+          alt={`${repo.repo_name} preview`}
+          fill
+          className="object-cover"
+          onError={() => setImageError(true)}
+          sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+        />
+        {/* Source badge */}
+        {screenshotSource && (
+          <div className="absolute bottom-2 right-2 px-2 py-1 bg-black/60 backdrop-blur-sm rounded text-[10px] text-white font-medium">
+            {screenshotSource === "captured" ? "Live" : "GitHub"}
+          </div>
         )}
-        {repo.repo_stars > 0 && (
+        {/* Capture button overlay */}
+        {repo.live_demo_url && (
+          <button
+            onClick={handleCapture}
+            disabled={isCapturing}
+            className="absolute top-2 right-2 p-2 bg-black/60 backdrop-blur-sm rounded-lg text-white hover:bg-black/80 transition-all disabled:opacity-50"
+            title="Capture screenshot"
+          >
+            {isCapturing ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <Camera className="w-4 h-4" />
+            )}
+          </button>
+        )}
+      </div>
+
+      {/* Card content */}
+      <a
+        href={repo.repo_url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="block p-5"
+      >
+        <div className="flex items-start justify-between mb-3">
+          <span className="font-semibold">{repo.repo_name}</span>
+          <span className="px-2 py-1 bg-[var(--color-surface-elevated)] rounded text-[11px] text-[var(--color-text-secondary)] uppercase tracking-wide">
+            Public
+          </span>
+        </div>
+        {repo.repo_description && (
+          <p className="text-sm text-[var(--color-text-secondary)] line-clamp-2 mb-4">
+            {repo.repo_description}
+          </p>
+        )}
+        <div className="flex items-center gap-4">
+          {repo.repo_language && (
+            <span className="flex items-center gap-1.5 text-sm text-[var(--color-text-secondary)]">
+              <span
+                className="w-2.5 h-2.5 rounded-full"
+                style={{ backgroundColor: languageColor || "#6e7681" }}
+              />
+              {repo.repo_language}
+            </span>
+          )}
+          {repo.repo_stars > 0 && (
+            <span className="flex items-center gap-1 text-sm text-[var(--color-text-secondary)]">
+              <Star className="w-3.5 h-3.5 fill-amber-400 text-amber-400" />
+              {repo.repo_stars}
+            </span>
+          )}
           <span className="flex items-center gap-1 text-sm text-[var(--color-text-secondary)]">
-            <Star className="w-3.5 h-3.5 fill-amber-400 text-amber-400" />
-            {repo.repo_stars}
+            <Share2 className="w-3.5 h-3.5" />0
           </span>
-        )}
-        <span className="flex items-center gap-1 text-sm text-[var(--color-text-secondary)]">
-          <Share2 className="w-3.5 h-3.5" />0
-        </span>
-      </div>
-    </a>
+        </div>
+      </a>
+    </div>
   )
 }

--- a/components/ProjectScreenshot.tsx
+++ b/components/ProjectScreenshot.tsx
@@ -1,0 +1,147 @@
+"use client"
+
+import { useState } from "react"
+import Image from "next/image"
+import { Camera, Loader2, ImageOff } from "lucide-react"
+
+interface ProjectScreenshotProps {
+  projectId: string
+  repoFullName: string
+  screenshotUrl: string | null
+  screenshotSource: "captured" | "github_og" | null
+  liveDemoUrl: string | null
+  canCapture: boolean
+  onScreenshotUpdated?: (url: string, source: "captured" | "github_og") => void
+}
+
+/**
+ * Build GitHub Open Graph image URL as fallback
+ */
+function buildGitHubOGUrl(repoFullName: string): string {
+  return `https://opengraph.githubassets.com/1/${repoFullName}`
+}
+
+/**
+ * ProjectScreenshot component displays a project screenshot with fallback to GitHub OG image
+ * and allows admins to capture new screenshots
+ */
+export default function ProjectScreenshot({
+  projectId,
+  repoFullName,
+  screenshotUrl,
+  screenshotSource,
+  liveDemoUrl,
+  canCapture,
+  onScreenshotUpdated,
+}: ProjectScreenshotProps) {
+  const [isCapturing, setIsCapturing] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [currentScreenshotUrl, setCurrentScreenshotUrl] = useState(screenshotUrl)
+  const [currentSource, setCurrentSource] = useState(screenshotSource)
+  const [imageError, setImageError] = useState(false)
+
+  // Determine the display URL with fallbacks
+  const displayUrl =
+    imageError || !currentScreenshotUrl
+      ? buildGitHubOGUrl(repoFullName)
+      : currentScreenshotUrl
+
+  const handleCapture = async () => {
+    if (!liveDemoUrl) {
+      setError("No live demo URL configured")
+      return
+    }
+
+    setIsCapturing(true)
+    setError(null)
+
+    try {
+      const response = await fetch(
+        `/api/projects/${projectId}/screenshot/capture`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ live_demo_url: liveDemoUrl }),
+        }
+      )
+
+      const data = await response.json()
+
+      if (!response.ok) {
+        throw new Error(data.error || "Failed to capture screenshot")
+      }
+
+      setCurrentScreenshotUrl(data.screenshot_url)
+      setCurrentSource(data.screenshot_source)
+      setImageError(false)
+
+      if (onScreenshotUpdated) {
+        onScreenshotUpdated(data.screenshot_url, data.screenshot_source)
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Capture failed")
+    } finally {
+      setIsCapturing(false)
+    }
+  }
+
+  return (
+    <div className="relative">
+      {/* Screenshot Image */}
+      <div className="relative aspect-video bg-[var(--color-surface-elevated)] rounded-lg overflow-hidden">
+        {displayUrl ? (
+          <Image
+            src={displayUrl}
+            alt="Project screenshot"
+            fill
+            className="object-cover"
+            onError={() => setImageError(true)}
+            sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
+          />
+        ) : (
+          <div className="flex items-center justify-center h-full">
+            <ImageOff className="w-8 h-8 text-[var(--color-text-secondary)]" />
+          </div>
+        )}
+
+        {/* Source badge */}
+        {currentSource && (
+          <div className="absolute bottom-2 right-2 px-2 py-1 bg-black/60 backdrop-blur-sm rounded text-[10px] text-white font-medium">
+            {currentSource === "captured" ? "Live Screenshot" : "GitHub Preview"}
+          </div>
+        )}
+      </div>
+
+      {/* Capture button for admins */}
+      {canCapture && (
+        <div className="mt-2">
+          <button
+            onClick={handleCapture}
+            disabled={isCapturing || !liveDemoUrl}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-[var(--color-text-secondary)] hover:text-[var(--color-text)] bg-[var(--color-surface)] border border-[var(--color-border)] rounded-lg hover:border-indigo-500/50 transition-all disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isCapturing ? (
+              <>
+                <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                Capturing...
+              </>
+            ) : (
+              <>
+                <Camera className="w-3.5 h-3.5" />
+                {currentScreenshotUrl ? "Recapture" : "Capture Screenshot"}
+              </>
+            )}
+          </button>
+
+          {!liveDemoUrl && (
+            <p className="mt-1 text-xs text-amber-500">
+              Set a live demo URL to capture screenshots
+            </p>
+          )}
+
+          {error && <p className="mt-1 text-xs text-red-500">{error}</p>}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -13,6 +13,16 @@ const nextConfig: NextConfig = {
         hostname: "lh3.googleusercontent.com",
         pathname: "/**",
       },
+      {
+        protocol: "https",
+        hostname: "opengraph.githubassets.com",
+        pathname: "/**",
+      },
+      {
+        protocol: "https",
+        hostname: "*.supabase.co",
+        pathname: "/storage/v1/object/public/**",
+      },
     ],
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "react-dom": "^19.0.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4.0.0",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -28,6 +29,7 @@
         "eslint-config-next": "^15.1.0",
         "jest": "^30.2.0",
         "jest-environment-jsdom": "^30.2.0",
+        "playwright": "^1.58.2",
         "tailwindcss": "^4.0.0",
         "typescript": "^5.7.2"
       }
@@ -2293,6 +2295,22 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -3240,24 +3258,37 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.3.tgz",
+      "integrity": "sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.6.tgz",
+      "integrity": "sha512-kQAVowdR33euIqeA0+VZTDqU+qo1IeVY+hrKYtZMio3Pg0P0vuh/kwRylLUddJhB6pf3q/botcOvRtx4IN1wqQ==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -8349,9 +8380,9 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.3.tgz",
+      "integrity": "sha512-M2GCs7Vk83NxkUyQV1bkABc4yxgz9kILhHImZiBPAZ9ybuvCb0/H7lEl5XvIg3g+9d4eNotkZA5IWwYl0tibaA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -9018,6 +9049,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4.0.0",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
@@ -31,6 +32,7 @@
     "eslint-config-next": "^15.1.0",
     "jest": "^30.2.0",
     "jest-environment-jsdom": "^30.2.0",
+    "playwright": "^1.58.2",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.7.2"
   }

--- a/supabase/migrations/20260224_add_screenshot_fields.sql
+++ b/supabase/migrations/20260224_add_screenshot_fields.sql
@@ -1,0 +1,22 @@
+-- Migration: Add screenshot fields to user_repos table
+-- This enables automatic screenshot capture for project live demos
+
+-- Add screenshot columns to user_repos table
+ALTER TABLE user_repos
+ADD COLUMN IF NOT EXISTS screenshot_url TEXT,
+ADD COLUMN IF NOT EXISTS screenshot_source TEXT CHECK (screenshot_source IN ('captured', 'github_og') OR screenshot_source IS NULL),
+ADD COLUMN IF NOT EXISTS screenshot_captured_at TIMESTAMPTZ;
+
+-- Add live_demo_url column to store the URL we capture screenshots from
+-- This is extracted from the project README or manually set by the user
+ALTER TABLE user_repos
+ADD COLUMN IF NOT EXISTS live_demo_url TEXT;
+
+-- Index for efficient queries on screenshot status
+CREATE INDEX IF NOT EXISTS idx_user_repos_screenshot_source ON user_repos(screenshot_source);
+
+-- Comments explaining the columns
+COMMENT ON COLUMN user_repos.screenshot_url IS 'Supabase Storage URL for the captured project screenshot';
+COMMENT ON COLUMN user_repos.screenshot_source IS 'Source of screenshot: captured (Playwright), github_og (GitHub Open Graph), or NULL';
+COMMENT ON COLUMN user_repos.screenshot_captured_at IS 'Timestamp when the screenshot was last captured';
+COMMENT ON COLUMN user_repos.live_demo_url IS 'URL of the live demo to capture screenshots from';


### PR DESCRIPTION
## Summary
- Add database migration for screenshot columns (screenshot_url, screenshot_source, screenshot_captured_at)
- Implement Playwright-based screenshot capture API endpoint
- Create ProjectScreenshot component with fallback chain
- Update project cards to display screenshots
- Add capture button for admin view

## Changes
- **Database**: New migration adds screenshot columns to user_repos table
- **API**: POST /api/projects/[id]/screenshot/capture endpoint
- **Frontend**: ProjectScreenshot component and updated project cards
- **Config**: Added image domains for GitHub OG and Supabase Storage

## Test plan
- [ ] Run database migration
- [ ] Verify API endpoint captures screenshots
- [ ] Check fallback to GitHub OG on failure
- [ ] Verify project cards display screenshots
- [ ] Test capture button functionality
- [ ] Run automated tests
- [ ] Build succeeds

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)