### PR TITLE
fix(#144): Check GitHub homepage field for screenshot capture

### DIFF
--- a/__tests__/lib/screenshot-utils.test.ts
+++ b/__tests__/lib/screenshot-utils.test.ts
@@ -1,4 +1,8 @@
-import { extractDemoUrl, getGitHubPreview } from "@/lib/screenshot-utils"
+import {
+  extractDemoUrl,
+  getGitHubPreview,
+  fetchRepoHomepage,
+} from "@/lib/screenshot-utils"
 
 describe("Screenshot Utils", () => {
   describe("extractDemoUrl", () => {
@@ -158,6 +162,105 @@ describe("Screenshot Utils", () => {
       )
       expect(() => getGitHubPreview(undefined as unknown as string)).toThrow(
         "Invalid repository name"
+      )
+    })
+  })
+
+  describe("fetchRepoHomepage", () => {
+    const originalFetch = global.fetch
+
+    afterEach(() => {
+      global.fetch = originalFetch
+    })
+
+    it("should return null for empty repo name", async () => {
+      expect(await fetchRepoHomepage("")).toBeNull()
+      expect(await fetchRepoHomepage(null as unknown as string)).toBeNull()
+      expect(await fetchRepoHomepage(undefined as unknown as string)).toBeNull()
+    })
+
+    it("should return homepage URL when present", async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            homepage: "https://skylineivy-react.netlify.app",
+          }),
+      })
+
+      const result = await fetchRepoHomepage("Avi-Aravindh/skylineivy-react")
+      expect(result).toBe("https://skylineivy-react.netlify.app")
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://api.github.com/repos/Avi-Aravindh/skylineivy-react",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Accept: "application/vnd.github+json",
+            "User-Agent": "LaunchLog/1.0",
+          }),
+        })
+      )
+    })
+
+    it("should return null when homepage is not set", async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            homepage: "",
+          }),
+      })
+
+      const result = await fetchRepoHomepage("user/repo-without-homepage")
+      expect(result).toBeNull()
+    })
+
+    it("should return null when homepage is null", async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            homepage: null,
+          }),
+      })
+
+      const result = await fetchRepoHomepage("user/repo-null-homepage")
+      expect(result).toBeNull()
+    })
+
+    it("should return null when API request fails", async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: false,
+        status: 404,
+      })
+
+      const result = await fetchRepoHomepage("nonexistent/repo")
+      expect(result).toBeNull()
+    })
+
+    it("should return null when fetch throws error", async () => {
+      global.fetch = jest.fn().mockRejectedValue(new Error("Network error"))
+
+      const result = await fetchRepoHomepage("user/repo")
+      expect(result).toBeNull()
+    })
+
+    it("should include Authorization header when token provided", async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            homepage: "https://example.com",
+          }),
+      })
+
+      await fetchRepoHomepage("user/repo", "test-github-token")
+      expect(global.fetch).toHaveBeenCalledWith(
+        "https://api.github.com/repos/user/repo",
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: "Bearer test-github-token",
+          }),
+        })
       )
     })
   })

--- a/app/api/projects/[id]/screenshot/capture/route.ts
+++ b/app/api/projects/[id]/screenshot/capture/route.ts
@@ -6,6 +6,7 @@ import {
   uploadToStorage,
   getGitHubPreview,
   fetchReadmeFromGitHub,
+  fetchRepoHomepage,
 } from "@/lib/screenshot-utils";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -36,7 +37,7 @@ interface CaptureResponse {
  */
 export async function POST(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse<CaptureResponse>> {
   const { id: projectId } = await params;
   const capturedAt = new Date().toISOString();
@@ -53,7 +54,7 @@ export async function POST(
         source: null,
         captured_at: capturedAt,
       },
-      { status: 400 }
+      { status: 400 },
     );
   }
 
@@ -72,7 +73,7 @@ export async function POST(
         source: null,
         captured_at: capturedAt,
       },
-      { status: 401 }
+      { status: 401 },
     );
   }
 
@@ -94,7 +95,7 @@ export async function POST(
         source: null,
         captured_at: capturedAt,
       },
-      { status: 404 }
+      { status: 404 },
     );
   }
 
@@ -108,7 +109,7 @@ export async function POST(
         source: null,
         captured_at: capturedAt,
       },
-      { status: 403 }
+      { status: 403 },
     );
   }
 
@@ -121,7 +122,7 @@ export async function POST(
         source: null,
         captured_at: capturedAt,
       },
-      { status: 400 }
+      { status: 400 },
     );
   }
 
@@ -136,34 +137,57 @@ export async function POST(
   const githubToken = tokenData?.access_token;
 
   // Try to capture screenshot from live demo
+  // Priority order: 1. GitHub homepage field, 2. README demo URL, 3. GitHub OG fallback
   let screenshotUrl: string | null = null;
   let source: "auto" | "github_og" = "github_og";
+  let demoUrl: string | null = null;
 
   try {
-    // Step 1: Fetch README from GitHub
-    const readme = await fetchReadmeFromGitHub(
+    // Step 1: Check GitHub homepage field first (most authoritative source)
+    const homepage = await fetchRepoHomepage(
       project.repo_full_name,
-      githubToken
+      githubToken,
     );
 
-    if (readme) {
-      // Step 2: Extract demo URL from README
-      const demoUrl = extractDemoUrl(readme);
-
-      if (demoUrl) {
-        // Step 3: Capture screenshot
-        console.log(`Capturing screenshot from: ${demoUrl}`);
-        const screenshotBuffer = await captureScreenshot(demoUrl);
-
-        // Step 4: Upload to Supabase Storage
-        screenshotUrl = await uploadToStorage(screenshotBuffer, projectId);
-        source = "auto";
-        console.log(`Screenshot captured and uploaded: ${screenshotUrl}`);
-      } else {
-        console.log("No demo URL found in README, using fallback");
+    if (homepage) {
+      // Validate that homepage is a valid URL
+      try {
+        new URL(homepage);
+        demoUrl = homepage;
+        console.log(`Found homepage URL: ${demoUrl}`);
+      } catch {
+        console.log(`Invalid homepage URL format: ${homepage}`);
       }
-    } else {
-      console.log("Could not fetch README, using fallback");
+    }
+
+    // Step 2: If no homepage, scan README for demo URL
+    if (!demoUrl) {
+      const readme = await fetchReadmeFromGitHub(
+        project.repo_full_name,
+        githubToken,
+      );
+
+      if (readme) {
+        demoUrl = extractDemoUrl(readme);
+        if (demoUrl) {
+          console.log(`Found demo URL in README: ${demoUrl}`);
+        } else {
+          console.log("No demo URL found in README, using fallback");
+        }
+      } else {
+        console.log("Could not fetch README, using fallback");
+      }
+    }
+
+    // Step 3: Capture screenshot if we have a demo URL
+    if (demoUrl) {
+      console.log(`Capturing screenshot from: ${demoUrl}`);
+      const screenshotBuffer = await captureScreenshot(demoUrl);
+
+      // Step 4: Upload to Supabase Storage
+      screenshotUrl = await uploadToStorage(screenshotBuffer, projectId);
+      source = "auto";
+      console.log(`Screenshot captured and uploaded: ${screenshotUrl}`);
     }
   } catch (error) {
     // Log the error but don't fail - we'll use the fallback
@@ -187,7 +211,7 @@ export async function POST(
           source: null,
           captured_at: capturedAt,
         },
-        { status: 500 }
+        { status: 500 },
       );
     }
   }
@@ -224,7 +248,7 @@ export async function POST(
  */
 export async function GET(
   request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
+  { params }: { params: Promise<{ id: string }> },
 ): Promise<NextResponse> {
   try {
     const { id: projectId } = await params;
@@ -235,7 +259,7 @@ export async function GET(
     if (!uuidRegex.test(projectId)) {
       return NextResponse.json(
         { error: "Invalid project ID format" },
-        { status: 400 }
+        { status: 400 },
       );
     }
 
@@ -254,7 +278,7 @@ export async function GET(
     const { data: project, error: projectError } = await supabaseAdmin
       .from("user_repos")
       .select(
-        "id, screenshot_url, screenshot_source, screenshot_captured_at, user_id"
+        "id, screenshot_url, screenshot_source, screenshot_captured_at, user_id",
       )
       .eq("id", projectId)
       .single();
@@ -267,7 +291,7 @@ export async function GET(
     if (project.user_id !== user.id) {
       return NextResponse.json(
         { error: "Not authorized to access this project" },
-        { status: 403 }
+        { status: 403 },
       );
     }
 
@@ -280,7 +304,7 @@ export async function GET(
     console.error("Error in screenshot GET API:", error);
     return NextResponse.json(
       { error: "Internal server error" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/lib/screenshot-utils.ts
+++ b/lib/screenshot-utils.ts
@@ -87,7 +87,7 @@ export function extractDemoUrl(readme: string): string | null {
 
       // Skip excluded URLs
       const isExcluded = EXCLUDED_URL_PATTERNS.some((excludePattern) =>
-        excludePattern.test(url)
+        excludePattern.test(url),
       );
 
       if (!isExcluded && url.startsWith("http")) {
@@ -175,7 +175,7 @@ export async function captureScreenshot(url: string): Promise<Buffer> {
  */
 export async function uploadToStorage(
   buffer: Buffer,
-  projectId: string
+  projectId: string,
 ): Promise<string> {
   if (!buffer || buffer.length === 0) {
     throw new Error("Empty buffer provided");
@@ -225,6 +225,48 @@ export function getGitHubPreview(repoFullName: string): string {
 }
 
 /**
+ * Fetch the homepage URL from GitHub repository metadata
+ * The homepage field is set in the repo's "About" section and is the most
+ * authoritative source for a project's live URL.
+ * @param repoFullName - The full repository name (e.g., "owner/repo")
+ * @param githubToken - Optional GitHub token for private repos or higher rate limits
+ * @returns The homepage URL or null if not set
+ */
+export async function fetchRepoHomepage(
+  repoFullName: string,
+  githubToken?: string,
+): Promise<string | null> {
+  if (!repoFullName) {
+    return null;
+  }
+
+  const headers: HeadersInit = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "LaunchLog/1.0",
+  };
+
+  if (githubToken) {
+    headers.Authorization = `Bearer ${githubToken}`;
+  }
+
+  try {
+    const response = await fetch(
+      `https://api.github.com/repos/${repoFullName}`,
+      { headers },
+    );
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const data = await response.json();
+    return data.homepage || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Fetch README content from GitHub API
  * @param repoFullName - The full repository name (e.g., "owner/repo")
  * @param githubToken - Optional GitHub token for private repos or higher rate limits
@@ -232,7 +274,7 @@ export function getGitHubPreview(repoFullName: string): string {
  */
 export async function fetchReadmeFromGitHub(
   repoFullName: string,
-  githubToken?: string
+  githubToken?: string,
 ): Promise<string | null> {
   if (!repoFullName) {
     return null;
@@ -250,7 +292,7 @@ export async function fetchReadmeFromGitHub(
   try {
     const response = await fetch(
       `https://api.github.com/repos/${repoFullName}/readme`,
-      { headers }
+      { headers },
     );
 
     if (!response.ok) {
@@ -283,7 +325,7 @@ export interface ScreenshotResult {
  */
 export async function captureWithFallback(
   repoFullName: string,
-  githubToken?: string
+  githubToken?: string,
 ): Promise<ScreenshotResult> {
   // Try to extract and capture from demo URL
   try {
@@ -303,7 +345,7 @@ export async function captureWithFallback(
         } catch (captureError) {
           console.warn(
             `Failed to capture screenshot from ${demoUrl}:`,
-            captureError
+            captureError,
           );
           // Fall through to GitHub preview
         }
@@ -312,7 +354,7 @@ export async function captureWithFallback(
   } catch (extractError) {
     console.warn(
       `Failed to extract demo URL for ${repoFullName}:`,
-      extractError
+      extractError,
     );
     // Fall through to GitHub preview
   }


### PR DESCRIPTION
## Summary

- Add `fetchRepoHomepage()` function to fetch homepage URL from GitHub API
- Update capture route to check homepage field before scanning README
- Add comprehensive tests for the new function (7 new test cases)

## Priority Order

1. **GitHub API `homepage` field** (most authoritative source)
2. **README demo URL scan** (existing behavior)
3. **GitHub OG fallback** (last resort)

## Test Plan

- [x] Test with repo that has homepage set (`Avi-Aravindh/skylineivy-react`)
- [x] Test with repo that only has README demo URL
- [x] Test with repo that has neither (falls back to GitHub OG)
- [x] All 150 tests pass
- [x] TypeScript compiles without errors
- [x] Lint and Prettier checks pass
- [x] Build succeeds

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)