### PR TITLE
fix(#148): Replace slow listUsers() with indexed github_username lookup

### DIFF
--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -94,54 +94,48 @@ interface SupabaseUser {
   github_username?: string;
 }
 
+/**
+ * Get user by GitHub username using direct indexed lookup on user_profiles table.
+ * This replaces the slow auth.admin.listUsers() call that fetched ALL users.
+ * Uses the github_username column with a unique index for O(1) lookup.
+ */
 async function getUserByUsername(
   username: string,
 ): Promise<SupabaseUser | null> {
   const supabase = getSupabaseAdmin();
 
-  // Query auth.users through Supabase admin API
-  // Look for users where the GitHub username matches
-  const { data: users, error } = await supabase.auth.admin.listUsers();
+  // Query user_profiles directly using indexed github_username column
+  // Case-insensitive lookup using ilike (index uses LOWER())
+  const { data: profile, error: profileError } = await supabase
+    .from("user_profiles")
+    .select("user_id, github_username")
+    .ilike("github_username", username)
+    .single();
 
-  if (error || !users) {
-    console.error("Error listing users:", error);
+  if (profileError || !profile) {
+    // Profile not found or error - return null (will show "coming soon" page)
+    if (profileError && profileError.code !== "PGRST116") {
+      console.error("Error fetching profile by username:", profileError);
+    }
     return null;
   }
 
-  // Find user by GitHub username in their metadata or identities
-  const user = users.users.find((u) => {
-    const githubIdentity = u.identities?.find(
-      (identity) => identity.provider === "github",
-    );
-    const githubUsername =
-      githubIdentity?.identity_data?.user_name ||
-      u.user_metadata?.user_name ||
-      u.user_metadata?.preferred_username;
+  // Get user details from auth.users using the user_id from profile
+  const { data: authUser, error: authError } =
+    await supabase.auth.admin.getUserById(profile.user_id);
 
-    return (
-      githubUsername?.toLowerCase() === username.toLowerCase() ||
-      u.user_metadata?.name?.toLowerCase() === username.toLowerCase()
-    );
-  });
-
-  if (!user) {
+  if (authError || !authUser?.user) {
+    console.error("Error fetching auth user:", authError);
     return null;
   }
 
-  // Get GitHub username for the profile
-  const githubIdentity = user.identities?.find(
-    (identity) => identity.provider === "github",
-  );
-  const githubUsername =
-    githubIdentity?.identity_data?.user_name ||
-    user.user_metadata?.user_name ||
-    user.user_metadata?.preferred_username;
+  const user = authUser.user;
 
   return {
     id: user.id,
     email: user.email || null,
     raw_user_meta_data: user.user_metadata || {},
-    github_username: githubUsername,
+    github_username: profile.github_username || undefined,
   };
 }
 

--- a/app/api/user/profile/route.ts
+++ b/app/api/user/profile/route.ts
@@ -1,17 +1,17 @@
-import { createSupabaseServerClient } from "@/lib/supabase/server"
-import { getSupabaseAdmin } from "@/lib/supabase"
-import { NextResponse } from "next/server"
-import { revalidatePath } from "next/cache"
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { getSupabaseAdmin } from "@/lib/supabase";
+import { NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
 
 interface UserProfile {
-  id: string
-  user_id: string
-  bio: string | null
-  twitter_url: string | null
-  website_url: string | null
-  linkedin_url: string | null
-  created_at: string
-  updated_at: string
+  id: string;
+  user_id: string;
+  bio: string | null;
+  twitter_url: string | null;
+  website_url: string | null;
+  linkedin_url: string | null;
+  created_at: string;
+  updated_at: string;
 }
 
 /**
@@ -20,69 +20,72 @@ interface UserProfile {
  */
 export async function GET() {
   try {
-    const supabase = await createSupabaseServerClient()
+    const supabase = await createSupabaseServerClient();
     const {
       data: { user },
       error: authError,
-    } = await supabase.auth.getUser()
+    } = await supabase.auth.getUser();
 
     if (authError || !user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
     // Use admin client to fetch profile (bypasses RLS for consistent reads)
-    const adminClient = getSupabaseAdmin()
+    const adminClient = getSupabaseAdmin();
     const { data: profile, error: profileError } = await adminClient
       .from("user_profiles")
       .select("*")
       .eq("user_id", user.id)
-      .single()
+      .single();
 
     if (profileError && profileError.code !== "PGRST116") {
       // PGRST116 = no rows returned, which is fine for new users
-      console.error("Error fetching profile:", profileError)
+      console.error("Error fetching profile:", profileError);
       return NextResponse.json(
         { error: "Failed to fetch profile" },
-        { status: 500 }
-      )
+        { status: 500 },
+      );
     }
 
     // Get GitHub URL from user metadata (auto-populated from OAuth)
     const githubIdentity = user.identities?.find(
-      (identity) => identity.provider === "github"
-    )
+      (identity) => identity.provider === "github",
+    );
     const githubUsername =
       githubIdentity?.identity_data?.user_name ||
       user.user_metadata?.user_name ||
-      user.user_metadata?.preferred_username
+      user.user_metadata?.preferred_username;
 
     const githubUrl = githubUsername
       ? `https://github.com/${githubUsername}`
-      : null
+      : null;
 
     return NextResponse.json({
       profile: profile || null,
       github_url: githubUrl,
-    })
+    });
   } catch (error) {
-    console.error("Error in GET /api/user/profile:", error)
+    console.error("Error in GET /api/user/profile:", error);
     return NextResponse.json(
       { error: "Internal server error" },
-      { status: 500 }
-    )
+      { status: 500 },
+    );
   }
 }
 
 // URL validation regex patterns
-const URL_REGEX = /^https?:\/\/.+/
-const TWITTER_REGEX = /^https?:\/\/(www\.)?(twitter\.com|x\.com)\/.+/i
-const LINKEDIN_REGEX = /^https?:\/\/(www\.)?linkedin\.com\/.+/i
+const URL_REGEX = /^https?:\/\/.+/;
+const TWITTER_REGEX = /^https?:\/\/(www\.)?(twitter\.com|x\.com)\/.+/i;
+const LINKEDIN_REGEX = /^https?:\/\/(www\.)?linkedin\.com\/.+/i;
 
-function validateUrl(url: string | null | undefined, pattern?: RegExp): boolean {
-  if (!url || url.trim() === "") return true // Empty is valid
-  if (!URL_REGEX.test(url)) return false
-  if (pattern && !pattern.test(url)) return false
-  return true
+function validateUrl(
+  url: string | null | undefined,
+  pattern?: RegExp,
+): boolean {
+  if (!url || url.trim() === "") return true; // Empty is valid
+  if (!URL_REGEX.test(url)) return false;
+  if (pattern && !pattern.test(url)) return false;
+  return true;
 }
 
 /**
@@ -91,59 +94,74 @@ function validateUrl(url: string | null | undefined, pattern?: RegExp): boolean 
  */
 export async function PUT(request: Request) {
   try {
-    const supabase = await createSupabaseServerClient()
+    const supabase = await createSupabaseServerClient();
     const {
       data: { user },
       error: authError,
-    } = await supabase.auth.getUser()
+    } = await supabase.auth.getUser();
 
     if (authError || !user) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const body = await request.json()
-    const { bio, twitter_url, website_url, linkedin_url } = body
+    const body = await request.json();
+    const { bio, twitter_url, website_url, linkedin_url } = body;
 
     // Validate bio length
     if (bio && typeof bio === "string" && bio.length > 200) {
       return NextResponse.json(
         { error: "Bio must be 200 characters or less" },
-        { status: 400 }
-      )
+        { status: 400 },
+      );
     }
 
     // Validate URLs
     if (!validateUrl(twitter_url, TWITTER_REGEX)) {
       return NextResponse.json(
-        { error: "Invalid Twitter URL. Must be a valid twitter.com or x.com URL" },
-        { status: 400 }
-      )
+        {
+          error:
+            "Invalid Twitter URL. Must be a valid twitter.com or x.com URL",
+        },
+        { status: 400 },
+      );
     }
 
     if (!validateUrl(website_url)) {
       return NextResponse.json(
         { error: "Invalid website URL. Must start with http:// or https://" },
-        { status: 400 }
-      )
+        { status: 400 },
+      );
     }
 
     if (!validateUrl(linkedin_url, LINKEDIN_REGEX)) {
       return NextResponse.json(
         { error: "Invalid LinkedIn URL. Must be a valid linkedin.com URL" },
-        { status: 400 }
-      )
+        { status: 400 },
+      );
     }
 
     // Use admin client for upsert
-    const adminClient = getSupabaseAdmin()
+    const adminClient = getSupabaseAdmin();
 
-    const profileData: Partial<UserProfile> = {
+    // Get GitHub username from user metadata to ensure it's always set
+    const githubIdentityForProfile = user.identities?.find(
+      (identity) => identity.provider === "github",
+    );
+    const githubUsernameForProfile =
+      githubIdentityForProfile?.identity_data?.user_name ||
+      user.user_metadata?.user_name ||
+      user.user_metadata?.preferred_username;
+
+    const profileData: Partial<UserProfile> & { github_username?: string } = {
       user_id: user.id,
       bio: bio?.trim() || null,
       twitter_url: twitter_url?.trim() || null,
       website_url: website_url?.trim() || null,
       linkedin_url: linkedin_url?.trim() || null,
-    }
+      ...(githubUsernameForProfile && {
+        github_username: githubUsernameForProfile,
+      }),
+    };
 
     const { data: profile, error: upsertError } = await adminClient
       .from("user_profiles")
@@ -151,35 +169,35 @@ export async function PUT(request: Request) {
         onConflict: "user_id",
       })
       .select()
-      .single()
+      .single();
 
     if (upsertError) {
-      console.error("Error upserting profile:", upsertError)
+      console.error("Error upserting profile:", upsertError);
       return NextResponse.json(
         { error: "Failed to update profile" },
-        { status: 500 }
-      )
+        { status: 500 },
+      );
     }
 
     // Revalidate the user's public profile page to reflect changes immediately
     const githubIdentity = user.identities?.find(
-      (identity) => identity.provider === "github"
-    )
+      (identity) => identity.provider === "github",
+    );
     const githubUsername =
       githubIdentity?.identity_data?.user_name ||
       user.user_metadata?.user_name ||
-      user.user_metadata?.preferred_username
+      user.user_metadata?.preferred_username;
 
     if (githubUsername) {
-      revalidatePath(`/${githubUsername}`)
+      revalidatePath(`/${githubUsername}`);
     }
 
-    return NextResponse.json({ profile })
+    return NextResponse.json({ profile });
   } catch (error) {
-    console.error("Error in PUT /api/user/profile:", error)
+    console.error("Error in PUT /api/user/profile:", error);
     return NextResponse.json(
       { error: "Internal server error" },
-      { status: 500 }
-    )
+      { status: 500 },
+    );
   }
 }

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,16 +1,16 @@
-import { createServerClient } from "@supabase/ssr"
-import { cookies } from "next/headers"
-import { NextResponse } from "next/server"
-import { getSupabaseAdmin } from "@/lib/supabase"
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+import { getSupabaseAdmin } from "@/lib/supabase";
 
 export async function GET(request: Request) {
-  const { searchParams, origin } = new URL(request.url)
-  const code = searchParams.get("code")
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get("code");
   // Default to onboarding, but we'll check if user has repos
-  const explicitNext = searchParams.get("next")
+  const explicitNext = searchParams.get("next");
 
   if (code) {
-    const cookieStore = await cookies()
+    const cookieStore = await cookies();
 
     const supabase = createServerClient(
       process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -18,33 +18,34 @@ export async function GET(request: Request) {
       {
         cookies: {
           getAll() {
-            return cookieStore.getAll()
+            return cookieStore.getAll();
           },
           setAll(cookiesToSet) {
             cookiesToSet.forEach(({ name, value, options }) =>
               cookieStore.set(name, value, {
                 ...options,
-                secure: true,        // Force HTTPS cookies
-                sameSite: "lax",     // CSRF protection
-                httpOnly: false,     // Supabase needs client access
-              })
-            )
+                secure: true, // Force HTTPS cookies
+                sameSite: "lax", // CSRF protection
+                httpOnly: false, // Supabase needs client access
+              }),
+            );
           },
         },
-      }
-    )
+      },
+    );
 
-    const { data: sessionData, error } = await supabase.auth.exchangeCodeForSession(code)
+    const { data: sessionData, error } =
+      await supabase.auth.exchangeCodeForSession(code);
 
     if (!error && sessionData.session) {
       // Store the GitHub provider token for later API calls
       // provider_token is only available immediately after OAuth exchange
-      const providerToken = sessionData.session.provider_token
-      const providerRefreshToken = sessionData.session.provider_refresh_token
-      const userId = sessionData.session.user.id
+      const providerToken = sessionData.session.provider_token;
+      const providerRefreshToken = sessionData.session.provider_refresh_token;
+      const userId = sessionData.session.user.id;
 
       if (providerToken) {
-        const supabaseAdmin = getSupabaseAdmin()
+        const supabaseAdmin = getSupabaseAdmin();
 
         // Upsert the GitHub token to user_tokens table
         const { error: tokenError } = await supabaseAdmin
@@ -59,57 +60,86 @@ export async function GET(request: Request) {
             },
             {
               onConflict: "user_id,provider",
-            }
-          )
+            },
+          );
 
         if (tokenError) {
-          console.error("Error storing GitHub token:", tokenError)
+          console.error("Error storing GitHub token:", tokenError);
           // Continue anyway - don't block auth flow
+        }
+
+        // Extract GitHub username from session metadata for profile lookups
+        const githubUsername =
+          sessionData.session.user.user_metadata?.user_name ||
+          sessionData.session.user.user_metadata?.preferred_username;
+
+        // Upsert user_profiles with github_username for fast profile page lookups
+        // This replaces the slow auth.admin.listUsers() call
+        if (githubUsername) {
+          const { error: profileError } = await supabaseAdmin
+            .from("user_profiles")
+            .upsert(
+              {
+                user_id: userId,
+                github_username: githubUsername,
+              },
+              {
+                onConflict: "user_id",
+              },
+            );
+
+          if (profileError) {
+            console.error(
+              "Error upserting user profile with github_username:",
+              profileError,
+            );
+            // Continue anyway - don't block auth flow
+          }
         }
       }
 
       // Determine redirect destination
-      let redirectPath = explicitNext
+      let redirectPath = explicitNext;
 
       // If no explicit next param, check if user has completed onboarding
       if (!redirectPath) {
-        const user = sessionData.session.user
+        const user = sessionData.session.user;
 
         if (user) {
           // Check if user has existing repos (completed onboarding)
-          const supabaseAdmin = getSupabaseAdmin()
+          const supabaseAdmin = getSupabaseAdmin();
           const { data: userRepos, error: reposError } = await supabaseAdmin
             .from("user_repos")
             .select("id")
             .eq("user_id", user.id)
-            .limit(1)
+            .limit(1);
 
           if (!reposError && userRepos && userRepos.length > 0) {
             // User has repos, skip onboarding
-            redirectPath = "/dashboard"
+            redirectPath = "/dashboard";
           } else {
             // New user or no repos, go to onboarding
-            redirectPath = "/onboarding"
+            redirectPath = "/onboarding";
           }
         } else {
           // No user found, default to onboarding
-          redirectPath = "/onboarding"
+          redirectPath = "/onboarding";
         }
       }
 
-      const forwardedHost = request.headers.get("x-forwarded-host")
-      const isLocalEnv = process.env.NODE_ENV === "development"
+      const forwardedHost = request.headers.get("x-forwarded-host");
+      const isLocalEnv = process.env.NODE_ENV === "development";
 
       if (isLocalEnv) {
-        return NextResponse.redirect(`${origin}${redirectPath}`)
+        return NextResponse.redirect(`${origin}${redirectPath}`);
       } else if (forwardedHost) {
-        return NextResponse.redirect(`https://${forwardedHost}${redirectPath}`)
+        return NextResponse.redirect(`https://${forwardedHost}${redirectPath}`);
       } else {
-        return NextResponse.redirect(`${origin}${redirectPath}`)
+        return NextResponse.redirect(`${origin}${redirectPath}`);
       }
     }
   }
 
   // Return the user to an error page with instructions
-  return NextResponse.redirect(`${origin}/signin?error=auth_callback_error`)
+  return NextResponse.redirect(`${origin}/signin?error=auth_callback_error`);
 }

--- a/supabase/migrations/20260225_add_github_username_column.sql
+++ b/supabase/migrations/20260225_add_github_username_column.sql
@@ -1,0 +1,45 @@
+-- Migration: Add github_username column to user_profiles for fast profile lookups
+-- This replaces the slow auth.admin.listUsers() call with a direct indexed query
+
+-- Add github_username column
+ALTER TABLE user_profiles
+ADD COLUMN IF NOT EXISTS github_username TEXT;
+
+-- Create unique index on lowercase github_username for case-insensitive lookups
+CREATE UNIQUE INDEX IF NOT EXISTS idx_user_profiles_github_username_lower
+ON user_profiles (LOWER(github_username))
+WHERE github_username IS NOT NULL;
+
+-- Backfill existing profiles from auth.users metadata
+-- This uses a DO block to iterate through existing profiles and populate github_username
+DO $$
+DECLARE
+  profile_record RECORD;
+  github_username_value TEXT;
+BEGIN
+  FOR profile_record IN
+    SELECT up.id, up.user_id
+    FROM user_profiles up
+    WHERE up.github_username IS NULL
+  LOOP
+    -- Get github_username from auth.users raw_user_meta_data
+    SELECT
+      COALESCE(
+        raw_user_meta_data->>'user_name',
+        raw_user_meta_data->>'preferred_username'
+      )
+    INTO github_username_value
+    FROM auth.users
+    WHERE id = profile_record.user_id;
+
+    -- Update the profile if we found a username
+    IF github_username_value IS NOT NULL THEN
+      UPDATE user_profiles
+      SET github_username = github_username_value
+      WHERE id = profile_record.id;
+    END IF;
+  END LOOP;
+END $$;
+
+-- Comment explaining the column's purpose
+COMMENT ON COLUMN user_profiles.github_username IS 'GitHub username for direct profile lookups. Populated from OAuth on signup/signin.';


### PR DESCRIPTION
## Summary

- Add `github_username` column to `user_profiles` table with unique index for fast lookups
- Update auth callback to populate `github_username` on signin
- Replace `listUsers()` call with direct indexed query on `user_profiles`
- Improve profile page load time from O(n) to O(1)

Fixes #148

## Changes

### Database Migration
- `supabase/migrations/20260225_add_github_username_column.sql`
  - Adds `github_username TEXT` column to `user_profiles`
  - Creates unique index on `LOWER(github_username)` for case-insensitive lookups
  - Backfills existing profiles from `auth.users` metadata

### Auth Callback (`app/auth/callback/route.ts`)
- Upserts `user_profiles` with `github_username` during OAuth signin
- Ensures new users have their profile created with username immediately

### Profile API (`app/api/user/profile/route.ts`)
- Sets `github_username` when saving profiles (backfill for existing users)

### Profile Page (`app/[username]/page.tsx`)
- **Before**: `getUserByUsername()` called `supabase.auth.admin.listUsers()` → fetched ALL users → O(n) scan
- **After**: Query `user_profiles` directly with indexed `github_username` → O(1) lookup
- Uses `getUserById()` for auth user details after finding profile

## Test plan

- [ ] Run migration on production database
- [ ] Profile pages load in <2 seconds
- [ ] `/Avi-Aravindh` works without timeout
- [ ] No `listUsers()` calls in logs
- [ ] New user signup creates profile with github_username
- [ ] Existing users get github_username backfilled on profile save

🤖 Generated with [Claude Code](https://claude.com/claude-code)