### PR TITLE
feat: Add activity status badges to project cards

### DIFF
--- a/app/[username]/ProjectCard.tsx
+++ b/app/[username]/ProjectCard.tsx
@@ -3,6 +3,12 @@
 import Image from "next/image";
 import { Star, ExternalLink, Code } from "lucide-react";
 import MentionsRow from "@/app/components/projects/MentionsRow";
+import {
+  type ActivityStatus,
+  getActivityStatus,
+  getActivityLabel,
+  getActivityBadgeClasses,
+} from "@/lib/activity-status";
 
 interface UserRepo {
   id: string;
@@ -17,6 +23,8 @@ interface UserRepo {
   screenshot_url: string | null;
   screenshot_source: string | null;
   demo_url: string | null;
+  updated_at?: string | null;
+  created_at?: string | null;
 }
 
 const LANGUAGE_COLORS: Record<string, string> = {
@@ -88,6 +96,22 @@ function getScreenshotUrl(repo: UserRepo): string | null {
 }
 
 /**
+ * Activity badge component for project cards
+ */
+function ActivityBadge({ status }: { status: ActivityStatus }) {
+  const label = getActivityLabel(status);
+  const classes = getActivityBadgeClasses(status);
+
+  return (
+    <span
+      className={`absolute top-3 right-3 px-2.5 py-1 rounded-full text-[11px] font-semibold uppercase tracking-wide ${classes}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+/**
  * ProjectScreenshot component - Displays project screenshot with fallback hierarchy
  * - Primary: screenshot_url from database
  * - Fallback 1: GitHub OpenGraph preview
@@ -96,9 +120,11 @@ function getScreenshotUrl(repo: UserRepo): string | null {
 function ProjectScreenshot({
   repo,
   onClick,
+  activityStatus,
 }: {
   repo: UserRepo;
   onClick?: () => void;
+  activityStatus?: ActivityStatus;
 }) {
   const screenshotUrl = getScreenshotUrl(repo);
   const gradient = repo.repo_language
@@ -128,6 +154,8 @@ function ProjectScreenshot({
         <div className="absolute inset-0 flex items-center justify-center">
           <Code className="w-12 h-12 text-white/60" />
         </div>
+        {/* Activity badge */}
+        {activityStatus && <ActivityBadge status={activityStatus} />}
       </div>
     );
   }
@@ -155,11 +183,15 @@ function ProjectScreenshot({
       />
       {/* Hover shadow overlay */}
       <div className="absolute inset-0 bg-black/0 group-hover/screenshot:bg-black/10 transition-colors duration-300" />
+      {/* Activity badge */}
+      {activityStatus && <ActivityBadge status={activityStatus} />}
     </div>
   );
 }
 
 export default function ProjectCard({ repo }: { repo: UserRepo }) {
+  // Calculate activity status from timestamps
+  const activityStatus = getActivityStatus(repo.updated_at, repo.created_at);
   const languageColor = repo.repo_language
     ? LANGUAGE_COLORS[repo.repo_language] || "#6e7681"
     : null;
@@ -174,7 +206,11 @@ export default function ProjectCard({ repo }: { repo: UserRepo }) {
   return (
     <div className="bg-[var(--color-surface)] border border-[var(--color-border)] rounded-xl hover:border-indigo-500/50 hover:shadow-lg transition-all duration-200 group overflow-hidden">
       {/* Screenshot section */}
-      <ProjectScreenshot repo={repo} onClick={handleScreenshotClick} />
+      <ProjectScreenshot
+        repo={repo}
+        onClick={handleScreenshotClick}
+        activityStatus={activityStatus}
+      />
 
       {/* Content section */}
       <div className="p-5">

--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -20,6 +20,8 @@ interface UserRepo {
   screenshot_url: string | null;
   screenshot_source: string | null;
   demo_url: string | null;
+  updated_at: string | null;
+  created_at: string | null;
 }
 
 interface UserProfile {

--- a/app/[username]/projects/ProjectCard.tsx
+++ b/app/[username]/projects/ProjectCard.tsx
@@ -1,7 +1,14 @@
 "use client";
 
 import Image from "next/image";
-import { Star, ExternalLink, GitFork, Code, MessageSquare, ChevronRight } from "lucide-react";
+import {
+  Star,
+  ExternalLink,
+  GitFork,
+  Code,
+  MessageSquare,
+  ChevronRight,
+} from "lucide-react";
 import { useState } from "react";
 import { MentionsModal } from "@/app/components/projects/MentionsModal";
 
@@ -26,7 +33,7 @@ interface EnrichedRepo {
   demo_url: string | null;
   updated_at: string | null;
   created_at: string | null;
-  activityStatus: "active" | "recent" | "archived";
+  activityStatus: "active" | "recent" | "archived" | "new";
   mentions: MentionCount;
 }
 
@@ -119,9 +126,13 @@ function getRelativeTime(dateString: string | null): string {
 function ActivityBadge({
   status,
 }: {
-  status: "active" | "recent" | "archived";
+  status: "active" | "recent" | "archived" | "new";
 }) {
   const config = {
+    new: {
+      label: "New",
+      classes: "bg-blue-500/15 text-blue-500",
+    },
     active: {
       label: "Active",
       classes: "bg-green-500/15 text-green-500",
@@ -132,7 +143,8 @@ function ActivityBadge({
     },
     archived: {
       label: "Archived",
-      classes: "bg-[var(--color-surface-elevated)] text-[var(--color-text-secondary)]",
+      classes:
+        "bg-[var(--color-surface-elevated)] text-[var(--color-text-secondary)]",
     },
   };
 

--- a/app/[username]/projects/ProjectsGrid.tsx
+++ b/app/[username]/projects/ProjectsGrid.tsx
@@ -3,10 +3,7 @@
 import { useState, useMemo } from "react";
 import { FolderOpen, Search } from "lucide-react";
 import { ProjectCard } from "./ProjectCard";
-import {
-  FilterContext,
-  useProjectFilters,
-} from "./ProjectsFilters";
+import { FilterContext, useProjectFilters } from "./ProjectsFilters";
 
 interface MentionCount {
   hackernews: number;
@@ -29,7 +26,7 @@ interface EnrichedRepo {
   demo_url: string | null;
   updated_at: string | null;
   created_at: string | null;
-  activityStatus: "active" | "recent" | "archived";
+  activityStatus: "active" | "recent" | "archived" | "new";
   mentions: MentionCount;
 }
 
@@ -39,17 +36,10 @@ interface ProjectsGridProps {
 
 const ITEMS_PER_PAGE = 12;
 
-export function ProjectsGrid({
-  projects,
-}: ProjectsGridProps) {
+export function ProjectsGrid({ projects }: ProjectsGridProps) {
   const filterState = useProjectFilters();
-  const {
-    searchQuery,
-    selectedLanguage,
-    selectedStatus,
-    sortBy,
-    setSortBy,
-  } = filterState;
+  const { searchQuery, selectedLanguage, selectedStatus, sortBy, setSortBy } =
+    filterState;
 
   const [currentPage, setCurrentPage] = useState(1);
 
@@ -108,7 +98,7 @@ export function ProjectsGrid({
         break;
       case "name":
         sorted.sort((a, b) =>
-          a.repo_name.toLowerCase().localeCompare(b.repo_name.toLowerCase())
+          a.repo_name.toLowerCase().localeCompare(b.repo_name.toLowerCase()),
         );
         break;
     }
@@ -214,10 +204,7 @@ export function ProjectsGrid({
 
                     if (!showPage) {
                       // Show ellipsis for gaps
-                      if (
-                        page === 2 ||
-                        page === totalPages - 1
-                      ) {
+                      if (page === 2 || page === totalPages - 1) {
                         return (
                           <span
                             key={page}
@@ -243,7 +230,7 @@ export function ProjectsGrid({
                         {page}
                       </button>
                     );
-                  }
+                  },
                 )}
 
                 <button

--- a/app/[username]/projects/page.tsx
+++ b/app/[username]/projects/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from "next";
 import { getSupabaseAdmin } from "@/lib/supabase";
+import { getActivityStatus } from "@/lib/activity-status";
 import { ArrowLeft, FolderOpen } from "lucide-react";
 import Link from "next/link";
 import Image from "next/image";
@@ -86,7 +87,7 @@ export async function generateMetadata({
  * Get user by GitHub username using direct indexed lookup on user_profiles table.
  */
 async function getUserByUsername(
-  username: string
+  username: string,
 ): Promise<SupabaseUser | null> {
   const supabase = getSupabaseAdmin();
 
@@ -147,7 +148,7 @@ async function getAllUserRepos(userId: string): Promise<UserRepo[]> {
  * Get mention counts for all repos
  */
 async function getMentionCounts(
-  repoIds: string[]
+  repoIds: string[],
 ): Promise<Record<string, MentionCount>> {
   if (repoIds.length === 0) return {};
 
@@ -181,28 +182,6 @@ async function getMentionCounts(
 }
 
 /**
- * Calculate activity status based on last update date
- * - "Active": updated within 30 days
- * - "Recently updated": 30-90 days
- * - "Archived": 90+ days
- */
-function getActivityStatus(
-  updatedAt: string | null
-): "active" | "recent" | "archived" {
-  if (!updatedAt) return "archived";
-
-  const now = new Date();
-  const updated = new Date(updatedAt);
-  const daysDiff = Math.floor(
-    (now.getTime() - updated.getTime()) / (1000 * 60 * 60 * 24)
-  );
-
-  if (daysDiff <= 30) return "active";
-  if (daysDiff <= 90) return "recent";
-  return "archived";
-}
-
-/**
  * Extract unique languages from repos
  */
 function extractLanguages(repos: UserRepo[]): string[] {
@@ -232,12 +211,17 @@ function getLanguageCounts(repos: UserRepo[]): Record<string, number> {
  * Calculate activity status counts
  */
 function getStatusCounts(
-  repos: UserRepo[]
+  repos: UserRepo[],
 ): Record<"active" | "recent" | "archived", number> {
   const counts = { active: 0, recent: 0, archived: 0 };
   repos.forEach((repo) => {
-    const status = getActivityStatus(repo.updated_at);
-    counts[status]++;
+    const status = getActivityStatus(repo.updated_at, repo.created_at);
+    // Treat "new" as "active" for counting purposes
+    if (status === "new") {
+      counts.active++;
+    } else {
+      counts[status]++;
+    }
   });
   return counts;
 }
@@ -291,7 +275,7 @@ export default async function ProjectsPage({ params }: PageProps) {
   const totalStars = repos.reduce((sum, repo) => sum + repo.repo_stars, 0);
   const totalMentions = Object.values(mentionCounts).reduce(
     (sum, counts) => sum + counts.hackernews + counts.reddit,
-    0
+    0,
   );
   const languages = extractLanguages(repos);
   const languageCounts = getLanguageCounts(repos);
@@ -300,7 +284,7 @@ export default async function ProjectsPage({ params }: PageProps) {
   // Enrich repos with activity status and mentions
   const enrichedRepos = repos.map((repo) => ({
     ...repo,
-    activityStatus: getActivityStatus(repo.updated_at),
+    activityStatus: getActivityStatus(repo.updated_at, repo.created_at),
     mentions: mentionCounts[repo.id] || { hackernews: 0, reddit: 0 },
   }));
 

--- a/lib/activity-status.ts
+++ b/lib/activity-status.ts
@@ -1,0 +1,80 @@
+/**
+ * Activity Status Utilities
+ *
+ * Calculate and display project activity status based on timestamps.
+ * Used across profile and projects pages to show whether a project
+ * is actively maintained, recently updated, or archived.
+ */
+
+export type ActivityStatus = "active" | "recent" | "archived" | "new";
+
+/**
+ * Calculate activity status based on timestamps
+ *
+ * Status logic:
+ * - "new": Created within last 7 days → Blue badge
+ * - "active": Updated within last 30 days → Green badge
+ * - "recent": Updated 30-90 days ago → Yellow/amber badge
+ * - "archived": Updated 90+ days ago → Gray badge
+ *
+ * Priority: "new" takes precedence over other statuses
+ */
+export function getActivityStatus(
+  updatedAt: string | null | undefined,
+  createdAt?: string | null | undefined,
+): ActivityStatus {
+  const now = new Date();
+
+  // Check if newly created (within 7 days)
+  if (createdAt) {
+    const created = new Date(createdAt);
+    const daysSinceCreated = Math.floor(
+      (now.getTime() - created.getTime()) / (1000 * 60 * 60 * 24),
+    );
+    if (daysSinceCreated <= 7) {
+      return "new";
+    }
+  }
+
+  // Check update status
+  if (!updatedAt) return "archived";
+
+  const updated = new Date(updatedAt);
+  const daysSinceUpdate = Math.floor(
+    (now.getTime() - updated.getTime()) / (1000 * 60 * 60 * 24),
+  );
+
+  if (daysSinceUpdate <= 30) return "active";
+  if (daysSinceUpdate <= 90) return "recent";
+  return "archived";
+}
+
+/**
+ * Get human-readable label for activity status
+ */
+export function getActivityLabel(status: ActivityStatus): string {
+  const labels: Record<ActivityStatus, string> = {
+    new: "New",
+    active: "Active",
+    recent: "Recently Updated",
+    archived: "Archived",
+  };
+  return labels[status];
+}
+
+/**
+ * Get badge styling classes for activity status
+ * Returns Tailwind classes for background and text color
+ */
+export function getActivityBadgeClasses(status: ActivityStatus): string {
+  const classes: Record<ActivityStatus, string> = {
+    new: "bg-blue-500/15 text-blue-500 dark:bg-blue-500/20 dark:text-blue-400",
+    active:
+      "bg-green-500/15 text-green-600 dark:bg-green-500/20 dark:text-green-400",
+    recent:
+      "bg-amber-500/15 text-amber-600 dark:bg-amber-500/20 dark:text-amber-400",
+    archived:
+      "bg-gray-500/10 text-gray-500 dark:bg-gray-500/15 dark:text-gray-400",
+  };
+  return classes[status];
+}


### PR DESCRIPTION
## Summary
- Add activity status indicators to project cards showing whether projects are actively maintained
- **New** (created within 7 days): Blue badge
- **Active** (updated within 30 days): Green badge
- **Recently Updated** (30-90 days ago): Amber badge
- **Archived** (90+ days ago): Gray badge

## Changes
- Create shared `lib/activity-status.ts` utility with helper functions
- Add `ActivityBadge` component to profile page `ProjectCard`
- Update projects page to use shared helper
- Support dark mode with appropriate styling

## Test plan
- [ ] Verify activity badges appear on profile page project cards
- [ ] Verify activity badges appear on projects page
- [ ] Check dark mode styling looks correct
- [ ] Verify status is calculated correctly based on timestamps

🤖 Generated with [Claude Code](https://claude.com/claude-code)