### PR TITLE
fix(#152, #156): Improve accessibility - touch targets and text size

### DIFF
--- a/app/[username]/ProjectCard.tsx
+++ b/app/[username]/ProjectCard.tsx
@@ -104,7 +104,7 @@ function ActivityBadge({ status }: { status: ActivityStatus }) {
 
   return (
     <span
-      className={`absolute top-3 right-3 px-2.5 py-1 rounded-full text-[11px] font-semibold uppercase tracking-wide ${classes}`}
+      className={`absolute top-3 right-3 px-2.5 py-1 rounded-full text-xs font-semibold uppercase tracking-wide ${classes}`}
     >
       {label}
     </span>

--- a/app/[username]/page.tsx
+++ b/app/[username]/page.tsx
@@ -298,18 +298,18 @@ export default async function ProfilePage({ params }: PageProps) {
               </p>
             )}
 
-            {/* Social Links */}
+            {/* Social Links - 44x44px minimum touch targets for WCAG AA compliance */}
             {hasSocialLinks && (
-              <div className="flex flex-wrap gap-4 justify-center md:justify-start">
+              <div className="flex flex-wrap gap-2 justify-center md:justify-start -ml-2">
                 {/* GitHub Link */}
                 {githubUrl && (
                   <a
                     href={githubUrl}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1.5 text-[var(--color-text-secondary)] text-sm font-medium hover:text-indigo-500 transition-colors"
+                    className="inline-flex items-center gap-1.5 text-[var(--color-text-secondary)] text-sm font-medium hover:text-indigo-500 transition-colors min-w-[44px] min-h-[44px] px-3 py-2 rounded-lg hover:bg-[var(--color-surface)]"
                   >
-                    <GithubIcon className="w-4 h-4" />
+                    <GithubIcon className="w-5 h-5" />
                     {user.github_username}
                   </a>
                 )}
@@ -320,9 +320,9 @@ export default async function ProfilePage({ params }: PageProps) {
                     href={profile.twitter_url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1.5 text-[var(--color-text-secondary)] text-sm font-medium hover:text-indigo-500 transition-colors"
+                    className="inline-flex items-center gap-1.5 text-[var(--color-text-secondary)] text-sm font-medium hover:text-indigo-500 transition-colors min-w-[44px] min-h-[44px] px-3 py-2 rounded-lg hover:bg-[var(--color-surface)]"
                   >
-                    <TwitterIcon className="w-4 h-4" />
+                    <TwitterIcon className="w-5 h-5" />
                     {extractDisplayFromUrl(profile.twitter_url, "twitter")}
                   </a>
                 )}
@@ -333,9 +333,9 @@ export default async function ProfilePage({ params }: PageProps) {
                     href={profile.website_url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1.5 text-[var(--color-text-secondary)] text-sm font-medium hover:text-indigo-500 transition-colors"
+                    className="inline-flex items-center gap-1.5 text-[var(--color-text-secondary)] text-sm font-medium hover:text-indigo-500 transition-colors min-w-[44px] min-h-[44px] px-3 py-2 rounded-lg hover:bg-[var(--color-surface)]"
                   >
-                    <WebsiteIcon className="w-4 h-4" />
+                    <WebsiteIcon className="w-5 h-5" />
                     {extractDisplayFromUrl(profile.website_url, "website")}
                   </a>
                 )}
@@ -346,9 +346,9 @@ export default async function ProfilePage({ params }: PageProps) {
                     href={profile.linkedin_url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1.5 text-[var(--color-text-secondary)] text-sm font-medium hover:text-indigo-500 transition-colors"
+                    className="inline-flex items-center gap-1.5 text-[var(--color-text-secondary)] text-sm font-medium hover:text-indigo-500 transition-colors min-w-[44px] min-h-[44px] px-3 py-2 rounded-lg hover:bg-[var(--color-surface)]"
                   >
-                    <LinkedinIcon className="w-4 h-4" />
+                    <LinkedinIcon className="w-5 h-5" />
                     LinkedIn
                   </a>
                 )}

--- a/app/[username]/projects/ProjectCard.tsx
+++ b/app/[username]/projects/ProjectCard.tsx
@@ -152,7 +152,7 @@ function ActivityBadge({
 
   return (
     <span
-      className={`absolute top-3 right-3 px-2.5 py-1 rounded-full text-[11px] font-semibold uppercase tracking-wide ${classes}`}
+      className={`absolute top-3 right-3 px-2.5 py-1 rounded-full text-xs font-semibold uppercase tracking-wide ${classes}`}
     >
       {label}
     </span>
@@ -299,7 +299,7 @@ export function ProjectCard({ project }: ProjectCardProps) {
         {/* Mentions Row */}
         {totalMentions > 0 ? (
           <div className="flex items-center gap-3 px-3 py-2.5 bg-[var(--color-surface-elevated)] rounded-lg mb-4">
-            <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-[var(--color-text-secondary)]">
+            <span className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-[var(--color-text-secondary)]">
               <MessageSquare className="w-3.5 h-3.5" />
               Mentions
             </span>
@@ -333,7 +333,7 @@ export function ProjectCard({ project }: ProjectCardProps) {
           </div>
         ) : (
           <div className="flex items-center gap-3 px-3 py-2.5 bg-[var(--color-surface-elevated)] rounded-lg mb-4">
-            <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-wider text-[var(--color-text-secondary)]">
+            <span className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wider text-[var(--color-text-secondary)]">
               <MessageSquare className="w-3.5 h-3.5" />
               Mentions
             </span>

--- a/app/components/projects/MentionsRow.tsx
+++ b/app/components/projects/MentionsRow.tsx
@@ -137,7 +137,7 @@ export function MentionsRow({ projectId, projectName, onViewAll }: MentionsRowPr
         role="status"
         aria-label="Loading mentions"
       >
-        <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.05em] text-[var(--color-text-secondary)]">
+        <span className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.05em] text-[var(--color-text-secondary)]">
           <MessageSquare className="w-3.5 h-3.5" aria-hidden="true" />
           Mentions
         </span>
@@ -155,7 +155,7 @@ export function MentionsRow({ projectId, projectName, onViewAll }: MentionsRowPr
         className="flex items-center gap-4 px-4 py-3.5 bg-[var(--color-surface-elevated)] rounded-[10px] mt-1"
         role="alert"
       >
-        <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.05em] text-[var(--color-text-secondary)]">
+        <span className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.05em] text-[var(--color-text-secondary)]">
           <MessageSquare className="w-3.5 h-3.5" aria-hidden="true" />
           Mentions
         </span>
@@ -169,7 +169,7 @@ export function MentionsRow({ projectId, projectName, onViewAll }: MentionsRowPr
   if (totalMentions === 0) {
     return (
       <div className="flex items-center gap-4 px-4 py-3.5 bg-[var(--color-surface-elevated)] rounded-[10px] mt-1">
-        <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.05em] text-[var(--color-text-secondary)]">
+        <span className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.05em] text-[var(--color-text-secondary)]">
           <MessageSquare className="w-3.5 h-3.5" aria-hidden="true" />
           Mentions
         </span>
@@ -183,7 +183,7 @@ export function MentionsRow({ projectId, projectName, onViewAll }: MentionsRowPr
   return (
     <div className="flex items-center gap-4 px-4 py-3.5 bg-[var(--color-surface-elevated)] rounded-[10px] mt-1">
       {/* Label */}
-      <span className="flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.05em] text-[var(--color-text-secondary)]">
+      <span className="flex items-center gap-1.5 text-xs font-semibold uppercase tracking-[0.05em] text-[var(--color-text-secondary)]">
         <MessageSquare className="w-3.5 h-3.5" aria-hidden="true" />
         Mentions
       </span>
@@ -220,7 +220,7 @@ export function MentionsRow({ projectId, projectName, onViewAll }: MentionsRowPr
       )}
 
       {/* Update frequency indicator */}
-      <span className="hidden sm:flex items-center gap-1 text-[11px] text-[var(--color-text-secondary)] opacity-70">
+      <span className="hidden sm:flex items-center gap-1 text-xs text-[var(--color-text-secondary)] opacity-70">
         <Info className="w-3 h-3" aria-hidden="true" />
         Updates daily
       </span>


### PR DESCRIPTION
## Summary
- Increases social link touch targets to 44×44px minimum for WCAG AA compliance
- Enlarges social icons from 16px to 20px with hover states
- Fixes text-[11px] to text-xs (12px) for MENTIONS labels across all components

## Changes
- `app/[username]/page.tsx`: Social links now have min-w-[44px] min-h-[44px] touch targets
- `app/[username]/ProjectCard.tsx`: ActivityBadge uses text-xs instead of text-[11px]
- `app/[username]/projects/ProjectCard.tsx`: ActivityBadge and MENTIONS labels use text-xs
- `app/components/projects/MentionsRow.tsx`: All MENTIONS labels use text-xs

## Test plan
- [ ] Verify touch targets are at least 44×44px on mobile
- [ ] Verify text size is 12px minimum (text-xs)
- [ ] Test on various screen sizes
- [ ] Confirm dark mode still works
- [ ] Check no console errors
- [ ] Verify design aesthetic maintained

Fixes #152
Fixes #156

🤖 Generated with [Claude Code](https://claude.com/claude-code)